### PR TITLE
some effect roasting improvements

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -64,7 +64,7 @@ export interface PlaywrightBrowserService {
   readonly close: Effect.Effect<void, PlaywrightError>;
 
   /**
-   * An Effect that returns the list of all open browser contexts.
+   * Returns the list of all open browser contexts.
    * @see {@link Browser.contexts}
    */
   readonly contexts: () => Array<typeof PlaywrightBrowserContext.Service>;
@@ -78,18 +78,18 @@ export interface PlaywrightBrowserService {
   >;
 
   /**
-   * An Effect that returns the browser type (chromium, firefox or webkit) that the browser belongs to.
+   * Returns the browser type (chromium, firefox or webkit) that the browser belongs to.
    * @see {@link Browser.browserType}
    */
   readonly browserType: () => BrowserType;
 
   /**
-   * An Effect that returns the version of the browser.
+   * Returns the version of the browser.
    * @see {@link Browser.version}
    */
   readonly version: () => string;
   /**
-   * An Effect that returns whether the browser is connected.
+   * Returns whether the browser is connected.
    * @see {@link Browser.isConnected}
    */
   readonly isConnected: () => boolean;

--- a/src/experimental/browser-utils.test.ts
+++ b/src/experimental/browser-utils.test.ts
@@ -17,7 +17,7 @@ layer(Playwright.layer)("BrowserUtils", (it) => {
       const context2 = yield* browser.newContext();
       yield* context2.newPage;
 
-      const pages = yield* BrowserUtils.allPages(browser);
+      const pages = BrowserUtils.allPages(browser);
       assert.strictEqual(pages.length, 3);
     }),
   );

--- a/src/experimental/browser-utils.ts
+++ b/src/experimental/browser-utils.ts
@@ -6,17 +6,14 @@ import type { PlaywrightBrowserService } from "../browser";
  * @category util
  */
 export const allPages = (browser: PlaywrightBrowserService) =>
-  Effect.sync(() =>
-    Array.flatten(browser.contexts().map((context) => context.pages())),
-  );
+  Array.flatten(browser.contexts().map((context) => context.pages()));
 
 /**
  * Returns all frames in the browser from all pages in all contexts.
  * @category util
  */
 export const allFrames = (browser: PlaywrightBrowserService) =>
-  allPages(browser).pipe(
-    Effect.flatMap((pages) => Effect.all(pages.map((page) => page.frames))),
+  Effect.all(allPages(browser).map((page) => page.frames)).pipe(
     Effect.map(Array.flatten),
   );
 

--- a/src/experimental/environment.ts
+++ b/src/experimental/environment.ts
@@ -9,8 +9,7 @@ import type { PlaywrightError } from "../errors";
  * `PlaywrightEnvironment` is a service that allows you to configure how browsers are launched once. You can then
  * use `PlaywrightEnvironment.browser` to start browsers scoped to the current lifetime. They will be closed when the scope is closed.
  *
- * You can use {@link withBrowser} to provide the `PlaywrightBrowser` service to the wrapped effect. This
- * also allows you to re-use the same browser as many times as you want.
+ * This service will not start a browser on its own. You can use {@link withBrowser} to provide the `PlaywrightBrowser` service to the wrapped effect.
  *
  * @since 0.1.0
  * @category tag
@@ -54,24 +53,28 @@ export class PlaywrightEnvironment extends Context.Tag(
  * @since 0.1.0
  * @category layer
  */
-export const layer = (browser: BrowserType, launchOptions?: LaunchOptions) => {
-  return Layer.effect(
-    PlaywrightEnvironment,
-    Playwright.pipe(
-      Effect.map((playwright) => {
-        return PlaywrightEnvironment.of({
-          browser: playwright.launchScoped(browser, launchOptions),
-        });
+export const layer = (browser: BrowserType, launchOptions?: LaunchOptions) =>
+  Playwright.pipe(
+    Effect.map((playwright) =>
+      PlaywrightEnvironment.of({
+        browser: playwright.launchScoped(browser, launchOptions),
       }),
-      Effect.provide(Playwright.layer),
     ),
+    Layer.effect(PlaywrightEnvironment),
+    Layer.provide(Playwright.layer),
   );
-};
+
+const withBrowserUnscoped = Effect.provideServiceEffect(
+  PlaywrightBrowser,
+  PlaywrightEnvironment.pipe(Effect.flatMap((e) => e.browser)),
+);
 
 /**
  * Provides a scoped `PlaywrightBrowser` service, allowing you to access the browser from the context (e.g. by yielding `PlaywrightBrowser`).
  *
  * You will need to provide the `PlaywrightEnvironment` layer first.
+ *
+ * This will start a browser and close it when the scope is closed.
  *
  * @example
  *
@@ -91,10 +94,5 @@ export const layer = (browser: BrowserType, launchOptions?: LaunchOptions) => {
  * @since 0.1.0
  * @category util
  */
-export const withBrowser = Effect.provide(
-  PlaywrightEnvironment.pipe(
-    Effect.map((e) => e.browser),
-    Effect.flatten,
-    Layer.scoped(PlaywrightBrowser),
-  ),
-);
+export const withBrowser = <A, E, R>(self: Effect.Effect<A, E, R>) =>
+  Effect.scoped(withBrowserUnscoped(self)); // TODO: roast check if using Effect.scope here is an anti-pattern


### PR DESCRIPTION
https://youtu.be/BzXg0A5Xsv8?t=3437

So.. about the `withBrowser`: it still [remains for now](https://github.com/Jobflow-io/effect-playwright/blob/c80ab6c6ad3088af89be970f77c015f793336043/src/experimental/environment.ts#L92-L97) because of api breakage, but also because i'm not sure what a better api would be.

## How this is supposed to work

You setup your base configuration once: What browser do i want? what settings?
This is the `PlaywrightEnvironment`. Basically just a service that knows how to start a browser. See here https://github.com/Jobflow-io/effect-playwright#playwrightenvironment-experimental

`withBrowser` is then supposed to actually launch the browser (with scope). It is supposed to be used multiple times like:

```ts
// launches one browsers
const program = Effect.gen(function* () {
  yield* checkOldEffectWebsite;
  yield* checkNewEffectWebsite;
}).pipe(PlaywrightEnvironment.withBrowser);

// launches two browsers
yield* checkOldEffectWebsite.pipe(PlaywrightEnvironment.withBrowser);
yield* checkNewEffectWebsite.pipe(PlaywrightEnvironment.withBrowser);

```

## New api?

So how would this API look without using Effect.provide internaly? Something like this?

```ts
export const browserLayer = Layer.scoped(
  PlaywrightBrowser,
  PlaywrightEnvironment.pipe(
    Effect.flatMap((e) => e.browser),
  ),
).pipe(Layer.fresh); // we want this to be re-created, to be able to launch multiple browsers

// in application code
const program = Effect.gen(function* () {
  const browser = yield* PlaywrightBrowser;
  const page = yield* browser.newPage();
  yield* page.goto("https://example.com");
}).pipe(Effect.provide(browserLayer)); // PlaywrightEnvironment also needs to be provided
```

or `export const browserLayer = () => Layer.scoped(…)` to remove the Layer fresh and make it more explicit that a new layer is created?

