### PR TITLE
a few more random methods

### DIFF
--- a/src/browser-context.test.ts
+++ b/src/browser-context.test.ts
@@ -75,5 +75,20 @@ layer(PlaywrightEnvironment.layer(chromium))(
         assert.strictEqual(magicValue2, 84);
       }).pipe(PlaywrightEnvironment.withBrowser),
     );
+
+    it.scoped(
+      "isClosed should return the closed state of the browser context",
+      () =>
+        Effect.gen(function* () {
+          const browser = yield* PlaywrightBrowser;
+          const context = yield* browser.newContext();
+
+          assert.strictEqual(context.isClosed(), false);
+
+          yield* context.close;
+
+          assert.strictEqual(context.isClosed(), true);
+        }).pipe(PlaywrightEnvironment.withBrowser),
+    );
   },
 );

--- a/src/browser-context.test.ts
+++ b/src/browser-context.test.ts
@@ -32,11 +32,28 @@ layer(PlaywrightEnvironment.layer(chromium))(
         assert.strictEqual(cookies.length, 1);
         assert.strictEqual(cookies[0].name, "test-cookie");
 
+        // Test storageState & setStorageState
+        const state = yield* context.storageState();
+        assert.isTrue(
+          state.cookies.some(
+            (c) => c.name === "test-cookie" && c.value === "test-value",
+          ),
+        );
+
         yield* context.clearCookies();
         const cookiesAfterClear = yield* context.cookies([
           "https://example.com",
         ]);
         assert.strictEqual(cookiesAfterClear.length, 0);
+
+        yield* context.setStorageState(state);
+        const cookiesAfterRestore = yield* context.cookies([
+          "https://example.com",
+        ]);
+        assert.strictEqual(cookiesAfterRestore.length, 1);
+        assert.strictEqual(cookiesAfterRestore[0].name, "test-cookie");
+
+        yield* context.clearCookies();
 
         // Test grantPermissions/clearPermissions
         yield* context.grantPermissions(["notifications"]);

--- a/src/browser-context.ts
+++ b/src/browser-context.ts
@@ -121,7 +121,7 @@ export interface PlaywrightBrowserContextService {
    * Indicates that the browser context is in the process of closing or has already been closed.
    *
    * @see {@link BrowserContext.isClosed}
-   * @since 0.6.0
+   * @since 0.5.1
    */
   readonly isClosed: () => boolean;
   /**
@@ -246,6 +246,20 @@ export interface PlaywrightBrowserContextService {
   readonly setDefaultTimeout: (timeout: number) => void;
 
   /**
+   * Returns storage state for this browser context, contains current cookies, local storage snapshot and IndexedDB
+   * snapshot.
+   *
+   * @see {@link BrowserContext.storageState}
+   * @since 0.5.1
+   */
+  readonly storageState: (
+    options?: Parameters<BrowserContext["storageState"]>[0],
+  ) => Effect.Effect<
+    Awaited<ReturnType<BrowserContext["storageState"]>>,
+    PlaywrightError
+  >;
+
+  /**
    * Sets the storage state for the browser context.
    *
    * @see {@link BrowserContext.setStorageState}
@@ -314,6 +328,7 @@ export class PlaywrightBrowserContext extends Context.Tag(
       setDefaultNavigationTimeout: (timeout) =>
         context.setDefaultNavigationTimeout(timeout),
       setDefaultTimeout: (timeout) => context.setDefaultTimeout(timeout),
+      storageState: (options) => use((c) => c.storageState(options)),
       setStorageState: (options) => use((c) => c.setStorageState(options)),
       eventStream: <K extends keyof BrowserContextEvents>(event: K) =>
         Stream.asyncPush<BrowserContextEvents[K]>((emit) =>

--- a/src/browser-context.ts
+++ b/src/browser-context.ts
@@ -118,6 +118,13 @@ export interface PlaywrightBrowserContextService {
    */
   readonly close: Effect.Effect<void, PlaywrightError>;
   /**
+   * Indicates that the browser context is in the process of closing or has already been closed.
+   *
+   * @see {@link BrowserContext.isClosed}
+   * @since 0.6.0
+   */
+  readonly isClosed: () => boolean;
+  /**
    * Adds a script which would be evaluated in one of the following scenarios:
    * - Whenever a page is created in the browser context or is navigated.
    * - Whenever a child frame is attached or navigated. In this case, the script is evaluated in the context of the newly attached frame.
@@ -287,6 +294,7 @@ export class PlaywrightBrowserContext extends Context.Tag(
       pages: () => context.pages().map(PlaywrightPage.make),
       newPage: use((c) => c.newPage().then(PlaywrightPage.make)),
       close: use((c) => c.close()),
+      isClosed: () => context.isClosed(),
       addInitScript: (script, arg) => use((c) => c.addInitScript(script, arg)),
       browser: () =>
         Option.fromNullable(context.browser()).pipe(

--- a/src/common.test.ts
+++ b/src/common.test.ts
@@ -40,6 +40,14 @@ layer(PlaywrightEnvironment.layer(chromium))("PlaywrightCommon", (it) => {
       const requestResponse = yield* request.response;
       assert(Option.isSome(requestResponse));
       assert(requestResponse.value.url() === response.url());
+
+      const existingResponse = request.existingResponse();
+      assert(Option.isSome(existingResponse));
+      assert(existingResponse.value.url() === response.url());
+
+      const httpVersion = yield* response.httpVersion;
+      assert(typeof httpVersion === "string");
+      assert(httpVersion.length > 0);
     }).pipe(PlaywrightEnvironment.withBrowser),
   );
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -29,6 +29,12 @@ export class PlaywrightRequest extends Data.TaggedClass("PlaywrightRequest")<{
     PlaywrightError
   >;
   /**
+   * Returns the matching Response object, or null if the response was not received yet.
+   * @see {@link Request.existingResponse}
+   * @since 0.5.1
+   */
+  existingResponse: () => Option.Option<PlaywrightResponse>;
+  /**
    * The method returns null unless this request was a failed one.
    * @see {@link Request.failure}
    */
@@ -134,6 +140,10 @@ export class PlaywrightRequest extends Data.TaggedClass("PlaywrightRequest")<{
 
     return new PlaywrightRequest({
       allHeaders: use(() => request.allHeaders()),
+      existingResponse: (): Option.Option<PlaywrightResponse> =>
+        Option.fromNullable(request.existingResponse()).pipe(
+          Option.map(PlaywrightResponse.make),
+        ),
       failure: Option.liftNullable(request.failure),
       frame: Effect.try({
         try: () => PlaywrightFrame.make(request.frame()),
@@ -206,6 +216,15 @@ export class PlaywrightResponse extends Data.TaggedClass("PlaywrightResponse")<{
     Awaited<ReturnType<Response["headerValues"]>>,
     PlaywrightError
   >;
+  /**
+   * Returns the HTTP version of the response.
+   * @see {@link Response.httpVersion}
+   * @since 0.5.1
+   */
+  httpVersion: Effect.Effect<
+    Awaited<ReturnType<Response["httpVersion"]>>,
+    PlaywrightError
+  >;
   json: Effect.Effect<Awaited<ReturnType<Response["json"]>>, PlaywrightError>;
   ok: () => boolean;
   request: () => PlaywrightRequest;
@@ -243,6 +262,7 @@ export class PlaywrightResponse extends Data.TaggedClass("PlaywrightResponse")<{
           Effect.map(Option.fromNullable),
         ),
       headerValues: (name) => use(() => response.headerValues(name)),
+      httpVersion: use(() => response.httpVersion()),
       json: use(() => response.json()),
       ok: () => response.ok(),
       request: () => PlaywrightRequest.make(response.request()),

--- a/src/frame.test.ts
+++ b/src/frame.test.ts
@@ -107,6 +107,14 @@ layer(PlaywrightEnvironment.layer(chromium))("PlaywrightFrame", (it) => {
       // Test waitForTimeout
       yield* frame.waitForTimeout(100);
 
+      // Test frameElement
+      const frameEl = yield* frame.frameElement;
+      assert.isOk(frameEl, "Frame element not found");
+      const tagName = yield* Effect.promise(() =>
+        frameEl.evaluate((el) => (el as any).tagName),
+      );
+      assert.strictEqual(tagName, "IFRAME");
+
       // Test setContent
       yield* frame.setContent("<h1>New Content</h1>");
       const newContent = yield* frame.content;

--- a/src/frame.ts
+++ b/src/frame.ts
@@ -1,5 +1,5 @@
 import { Array, Context, type Effect, Option } from "effect";
-import type { Frame } from "playwright-core";
+import type { ElementHandle, Frame } from "playwright-core";
 import type { PlaywrightError } from "./errors";
 import { PlaywrightLocator } from "./locator";
 import { PlaywrightPage, type PlaywrightPageService } from "./page";
@@ -223,6 +223,14 @@ export interface PlaywrightFrameService {
   readonly content: Effect.Effect<string, PlaywrightError>;
 
   /**
+   * Returns the owner iframe element for the frame.
+   *
+   * @see {@link Frame.frameElement}
+   * @since 0.5.1
+   */
+  readonly frameElement: Effect.Effect<ElementHandle, PlaywrightError>;
+
+  /**
    * Returns the frame name.
    *
    * @see {@link Frame.name}
@@ -297,6 +305,7 @@ export class PlaywrightFrame extends Context.Tag(
       setContent: (html, options) => use((f) => f.setContent(html, options)),
       url: () => frame.url(),
       content: use((f) => f.content()),
+      frameElement: use((f) => f.frameElement()),
       name: () => frame.name(),
       click: (selector, options) => use((f) => f.click(selector, options)),
     });


### PR DESCRIPTION
- Add the sync `isClosed()` method to `PlaywrightBrowserContext` interface and implementation.
- Add comprehensive test coverage verifying the closed state of a context before and after calling `close`.