### PR TITLE
initial playwright test implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
 
       - name: Install chromium
         run: pnpm exec playwright install chromium
+      - name: Playwright Test integration
+        run: pnpm test:playwright
+
 
       - name: Test
         run: pnpm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Features
+
+- **Playwright Test Shared Layers**: Added `layer` and `test.layer` to `effect-playwright/test`, with worker-scoped acquisition, nested layer composition, shared memoization, and custom fixture support.
+
 ## 0.5.0
 
 ### ⚠️ Breaking Changes

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 
 A Playwright wrapper for the Effect ecosystem. This library provides a set of services and layers to interact with Playwright in a type-safe way using Effect.
 
-> [!NOTE]
-> This library is currently focused on using Playwright for **automation** and **scraping**. It does not provide a wrapper for `@playwright/test` (the test runner).
+[Playwright Test Integration](README.md#playwright-test-integration) is also supported.
 
 ## Installation
 
@@ -190,4 +189,65 @@ pnpm effect-playwright codegen https://example.com
 
 # Open inspector / trace viewer
 pnpm effect-playwright show-trace trace.zip
+```
+
+## Playwright Test integration
+
+Install the optional Playwright Test peer dependency to use Effect programs in the upstream test runner:
+
+```bash
+pnpm add -D @playwright/test effect-playwright
+```
+
+```ts
+import { Effect } from "effect";
+import { PlaywrightPage } from "effect-playwright";
+import { expect, test } from "effect-playwright/test";
+
+test.effect("shows the example.com headline", () =>
+  Effect.gen(function* () {
+    const page = yield* PlaywrightPage;
+    yield* page.goto("https://example.com");
+
+    const headline = page.getByRole("heading", { name: "Example Domain" });
+    expect(yield* headline.innerText()).toBe("Example Domain");
+  }),
+);
+```
+
+### Utilizing Effect finalizers
+
+`test.effect` runs each Effect in a scope, so acquired resources are released when the test finishes, fails, or times out:
+
+```ts
+import { Effect } from "effect";
+import { test } from "effect-playwright/test";
+
+test.effect("cleans up after the test", () =>
+  Effect.acquireRelease(Effect.log("Creating User"), () =>
+    Effect.log("Cleanup: Deleting user"),
+  ),
+);
+```
+
+Effect scope finalizers run during test-scoped fixture teardown. On test timeout, this occurs after user `afterEach`.
+
+### Custom fixtures
+
+Call `makeMethods` after extending or merging a custom `TestType`:
+
+```ts
+import { test as base } from "@playwright/test";
+import { Effect } from "effect";
+import { expect, makeMethods } from "effect-playwright/test";
+
+const test = makeMethods(
+  base.extend<{ answer: number }>({
+    answer: async ({}, use) => use(42),
+  }),
+);
+
+test.effect("uses a custom fixture", ({ answer }) =>
+  Effect.sync(() => expect(answer).toBe(42)),
+);
 ```

--- a/README.md
+++ b/README.md
@@ -232,9 +232,34 @@ test.effect("cleans up after the test", () =>
 
 Effect scope finalizers run during test-scoped fixture teardown. On test timeout, this occurs after user `afterEach`.
 
-### Custom fixtures
+### Using Effect layers
 
-Call `makeMethods` after extending or merging a custom `TestType`:
+Effect layers are the preferred way to provide dependencies to Effect-based
+Playwright tests. Use `layer` to acquire a layer once per Playwright worker and
+share it between the tests in a block. Layer finalizers run after every test in
+the block has finished. Nested layers reuse their parent services.
+
+```ts
+import { Context, Effect, Layer } from "effect";
+import { expect, layer } from "effect-playwright/test";
+
+class Greeting extends Context.Tag("Greeting")<Greeting, string>() {}
+
+layer(Layer.succeed(Greeting, "hello"))("Greeting", (it) => {
+  it.effect("uses a shared service", () =>
+    Effect.gen(function* () {
+      expect(yield* Greeting).toBe("hello");
+    }),
+  );
+});
+```
+
+### Custom Playwright fixtures
+
+Custom Playwright fixtures are supported mainly for compatibility with existing
+Playwright Test suites. Prefer Effect layers.
+When integration with an existing custom `TestType` is required, call
+`makeMethods` after extending or merging it:
 
 ```ts
 import { test as base } from "@playwright/test";

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "exports": {
     ".": "./dist/index.mjs",
     "./experimental": "./dist/experimental/index.mjs",
+    "./test": "./dist/test.mjs",
     "./package.json": "./package.json"
   },
   "bin": {
@@ -29,6 +30,7 @@
     "build": "tsdown",
     "prepublishOnly": "pnpm build",
     "test": "vitest run",
+    "test:playwright": "playwright test src/test.spec.ts --workers=1 --output=tmp/playwright-test-results",
     "type-check": "tsc --noEmit",
     "coverage": "tsx scripts/coverage.ts",
     "generate-docs": "typedoc",
@@ -48,7 +50,13 @@
   },
   "peerDependencies": {
     "@effect/platform": "^0.93.3",
+    "@playwright/test": "^1.60.0",
     "effect": "^3.19.6"
+  },
+  "peerDependenciesMeta": {
+    "@playwright/test": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",
@@ -57,6 +65,7 @@
     "@effect/platform": "^0.96.1",
     "@effect/platform-node": "^0.107.0",
     "@effect/vitest": "^0.29.0",
+    "@playwright/test": "^1.60.0",
     "@types/node": "^25.9.1",
     "effect": "^3.21.2",
     "playwright": "^1.60.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@effect/vitest':
         specifier: ^0.29.0
         version: 0.29.0(effect@3.21.2)(vitest@4.1.8(@types/node@25.9.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0)))
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
@@ -549,6 +552,11 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -1636,6 +1644,10 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.5.6
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@quansync/fs@1.0.0':
     dependencies:

--- a/src/test.spec.ts
+++ b/src/test.spec.ts
@@ -28,6 +28,8 @@ class CustomLayerValue extends Context.Tag("CustomLayerValue")<
 
 let sharedLayerAcquisitions = 0;
 let sharedLayerReleases = 0;
+let anonymousLayerAcquisitions = 0;
+let anonymousLayerReleases = 0;
 
 const sharedLayer = Layer.scoped(
   SharedValue,
@@ -43,6 +45,20 @@ const sharedLayer = Layer.scoped(
 const nestedLayer = Layer.effect(
   NestedValue,
   Effect.map(SharedValue, ({ acquisition }) => acquisition + 1),
+);
+
+const anonymousLayer = Layer.scoped(
+  AnonymousValue,
+  Effect.acquireRelease(
+    Effect.sync(() => {
+      anonymousLayerAcquisitions += 1;
+      return "anonymous";
+    }),
+    () =>
+      Effect.sync(() => {
+        anonymousLayerReleases += 1;
+      }),
+  ),
 );
 
 test("runs an ordinary Promise-style test", async ({ page }) => {
@@ -79,6 +95,11 @@ layer(sharedLayer)("shared Effect layer", (it) => {
     }),
   );
 
+  it("preserves plain test source locations", ({ page }, testInfo) => {
+    expect(page).toBeDefined();
+    expect(testInfo.file).toMatch(/src[\\/]test\.spec\.ts$/);
+  });
+
   it.layer(nestedLayer)("nested Effect layer", (nestedIt) => {
     nestedIt.effect("provides parent and nested services", () =>
       Effect.gen(function* () {
@@ -94,12 +115,17 @@ test("releases a shared Effect layer", () => {
   expect(sharedLayerReleases).toBe(1);
 });
 
-layer(Layer.succeed(AnonymousValue, "anonymous"))((it) => {
+layer(anonymousLayer)((it) => {
   it.effect("supports an anonymous layer block", () =>
     Effect.gen(function* () {
       expect(yield* AnonymousValue).toBe("anonymous");
     }),
   );
+});
+
+test("releases an anonymous Effect layer", () => {
+  expect(anonymousLayerAcquisitions).toBe(1);
+  expect(anonymousLayerReleases).toBe(1);
 });
 
 const customTest = makeMethods(

--- a/src/test.spec.ts
+++ b/src/test.spec.ts
@@ -108,11 +108,12 @@ layer(sharedLayer)("shared Effect layer", (it) => {
       }),
     );
   });
-});
 
-test("releases a shared Effect layer", () => {
-  expect(sharedLayerAcquisitions).toBe(1);
-  expect(sharedLayerReleases).toBe(1);
+  // Runs after the layer's own release hook, which is registered first.
+  it.afterAll(() => {
+    expect(sharedLayerAcquisitions).toBe(1);
+    expect(sharedLayerReleases).toBe(1);
+  });
 });
 
 layer(anonymousLayer)((it) => {
@@ -121,11 +122,11 @@ layer(anonymousLayer)((it) => {
       expect(yield* AnonymousValue).toBe("anonymous");
     }),
   );
-});
 
-test("releases an anonymous Effect layer", () => {
-  expect(anonymousLayerAcquisitions).toBe(1);
-  expect(anonymousLayerReleases).toBe(1);
+  it.afterAll(() => {
+    expect(anonymousLayerAcquisitions).toBe(1);
+    expect(anonymousLayerReleases).toBe(1);
+  });
 });
 
 const customTest = makeMethods(

--- a/src/test.spec.ts
+++ b/src/test.spec.ts
@@ -1,0 +1,56 @@
+import { test as base } from "@playwright/test";
+import { Data, Effect } from "effect";
+import {
+  PlaywrightBrowser,
+  PlaywrightBrowserContext,
+  PlaywrightPage,
+} from "effect-playwright";
+import { expect, makeMethods, test } from "effect-playwright/test";
+
+class ExpectedTestError extends Data.TaggedError("ExpectedTestError") {}
+
+test("runs an ordinary Promise-style test", async ({ page }) => {
+  await page.goto("data:text/html,<title>Promise</title>");
+  await expect(page).toHaveTitle("Promise");
+});
+
+test.effect("uses the Playwright services", () =>
+  Effect.gen(function* () {
+    const page = yield* PlaywrightPage;
+    const context = yield* PlaywrightBrowserContext;
+    const browser = yield* PlaywrightBrowser;
+
+    yield* page.goto("data:text/html,<title>Effect Playwright</title>");
+    expect(yield* page.title).toBe("Effect Playwright");
+    expect(context.pages()).toHaveLength(1);
+    expect(browser.contexts()).toHaveLength(1);
+  }),
+);
+
+const customTest = makeMethods(
+  base.extend<{ value: string }>({
+    // biome-ignore lint/correctness/noEmptyPattern: Playwright requires fixture object destructuring.
+    value: async ({}, use) => use("custom fixture"),
+  }),
+);
+
+customTest.effect("uses a custom fixture", ({ value }) =>
+  Effect.sync(() => expect(value).toBe("custom fixture")),
+);
+
+test.effect("supports test details", { tag: "@effect" }, () => Effect.void);
+
+test("exposes every Effect modifier", async () => {
+  expect(typeof test.effect.only).toBe("function");
+  expect(typeof test.effect.skip).toBe("function");
+  expect(typeof test.effect.fixme).toBe("function");
+  expect(typeof test.effect.fail).toBe("function");
+  expect(typeof test.effect.fail.only).toBe("function");
+});
+
+test.effect.skip("supports skipped Effect tests", () => Effect.void);
+test.effect.fixme("supports Effect fixme tests", () => Effect.void);
+test.effect.fail(
+  "supports expected Effect failures",
+  () => new ExpectedTestError(),
+);

--- a/src/test.spec.ts
+++ b/src/test.spec.ts
@@ -1,13 +1,49 @@
 import { test as base } from "@playwright/test";
-import { Data, Effect } from "effect";
+import { Context, Data, Effect, Layer } from "effect";
 import {
   PlaywrightBrowser,
   PlaywrightBrowserContext,
   PlaywrightPage,
 } from "effect-playwright";
-import { expect, makeMethods, test } from "effect-playwright/test";
+import { expect, layer, makeMethods, test } from "effect-playwright/test";
 
 class ExpectedTestError extends Data.TaggedError("ExpectedTestError") {}
+
+class SharedValue extends Context.Tag("SharedValue")<
+  SharedValue,
+  { readonly acquisition: number }
+>() {}
+
+class NestedValue extends Context.Tag("NestedValue")<NestedValue, number>() {}
+
+class AnonymousValue extends Context.Tag("AnonymousValue")<
+  AnonymousValue,
+  string
+>() {}
+
+class CustomLayerValue extends Context.Tag("CustomLayerValue")<
+  CustomLayerValue,
+  string
+>() {}
+
+let sharedLayerAcquisitions = 0;
+let sharedLayerReleases = 0;
+
+const sharedLayer = Layer.scoped(
+  SharedValue,
+  Effect.acquireRelease(
+    Effect.sync(() => ({ acquisition: ++sharedLayerAcquisitions })),
+    () =>
+      Effect.sync(() => {
+        sharedLayerReleases += 1;
+      }),
+  ),
+);
+
+const nestedLayer = Layer.effect(
+  NestedValue,
+  Effect.map(SharedValue, ({ acquisition }) => acquisition + 1),
+);
 
 test("runs an ordinary Promise-style test", async ({ page }) => {
   await page.goto("data:text/html,<title>Promise</title>");
@@ -27,6 +63,45 @@ test.effect("uses the Playwright services", () =>
   }),
 );
 
+layer(sharedLayer)("shared Effect layer", (it) => {
+  it.effect("provides the layer service", () =>
+    Effect.gen(function* () {
+      const value = yield* SharedValue;
+      expect(value.acquisition).toBe(1);
+    }),
+  );
+
+  it.scoped("reuses one layer acquisition", () =>
+    Effect.gen(function* () {
+      const value = yield* SharedValue;
+      expect(value.acquisition).toBe(1);
+      expect(sharedLayerAcquisitions).toBe(1);
+    }),
+  );
+
+  it.layer(nestedLayer)("nested Effect layer", (nestedIt) => {
+    nestedIt.effect("provides parent and nested services", () =>
+      Effect.gen(function* () {
+        expect((yield* SharedValue).acquisition).toBe(1);
+        expect(yield* NestedValue).toBe(2);
+      }),
+    );
+  });
+});
+
+test("releases a shared Effect layer", () => {
+  expect(sharedLayerAcquisitions).toBe(1);
+  expect(sharedLayerReleases).toBe(1);
+});
+
+layer(Layer.succeed(AnonymousValue, "anonymous"))((it) => {
+  it.effect("supports an anonymous layer block", () =>
+    Effect.gen(function* () {
+      expect(yield* AnonymousValue).toBe("anonymous");
+    }),
+  );
+});
+
 const customTest = makeMethods(
   base.extend<{ value: string }>({
     // biome-ignore lint/correctness/noEmptyPattern: Playwright requires fixture object destructuring.
@@ -38,6 +113,18 @@ customTest.effect("uses a custom fixture", ({ value }) =>
   Effect.sync(() => expect(value).toBe("custom fixture")),
 );
 
+customTest.layer(Layer.succeed(CustomLayerValue, "custom layer"))(
+  "custom test layer",
+  (it) => {
+    it.effect("combines custom fixtures and layer services", ({ value }) =>
+      Effect.gen(function* () {
+        expect(value).toBe("custom fixture");
+        expect(yield* CustomLayerValue).toBe("custom layer");
+      }),
+    );
+  },
+);
+
 test.effect("supports test details", { tag: "@effect" }, () => Effect.void);
 
 test("exposes every Effect modifier", async () => {
@@ -46,6 +133,7 @@ test("exposes every Effect modifier", async () => {
   expect(typeof test.effect.fixme).toBe("function");
   expect(typeof test.effect.fail).toBe("function");
   expect(typeof test.effect.fail.only).toBe("function");
+  expect(typeof test.layer).toBe("function");
 });
 
 test.effect.skip("supports skipped Effect tests", () => Effect.void);

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,453 @@
+/**
+ * Playwright Test integration for Effect programs.
+ *
+ * Playwright Test owns its fixtures and their lifetimes. Effect programs receive
+ * non-owning wrappers for the active `browser`, `context`, and `page`; resources
+ * acquired by the program remain scoped to that program. Because Playwright does
+ * not expose a public test-completion signal, timeout interruption starts during
+ * test-scoped fixture teardown, after user `afterEach` hooks have run.
+ *
+ * @since 0.6.0
+ * @packageDocumentation
+ */
+
+import {
+  type Fixtures,
+  type PlaywrightTestArgs,
+  type PlaywrightWorkerArgs,
+  test as playwrightTest,
+  type TestDetails,
+  type TestInfo,
+  type TestType,
+} from "@playwright/test";
+import { Cause, Context, Effect, Exit, Logger, type Scope } from "effect";
+import { PlaywrightBrowser } from "./browser";
+import { PlaywrightBrowserContext } from "./browser-context";
+import { PlaywrightPage } from "./page";
+
+export * from "@playwright/test";
+
+/**
+ * Services available to an Effect-based Playwright test.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from "effect";
+ * import { PlaywrightPage } from "effect-playwright";
+ * import { expect, test } from "effect-playwright/test";
+ *
+ * test.effect("loads a page", () =>
+ *   Effect.gen(function* () {
+ *     const page = yield* PlaywrightPage;
+ *     yield* page.goto("data:text/html,<title>Effect</title>");
+ *     expect(yield* page.title).toBe("Effect");
+ *   }),
+ * );
+ * ```
+ *
+ * @see https://playwright.dev/docs/test-fixtures
+ * @since 0.6.0
+ */
+export type PlaywrightTestEnvironment =
+  | PlaywrightBrowser
+  | PlaywrightBrowserContext
+  | PlaywrightPage
+  | Scope.Scope;
+
+/**
+ * An Effect-returning Playwright Test callback.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from "effect";
+ * import { PlaywrightPage } from "effect-playwright";
+ * import { expect, test } from "effect-playwright/test";
+ *
+ * test.effect("loads a page", () =>
+ *   Effect.gen(function* () {
+ *     const page = yield* PlaywrightPage;
+ *     yield* page.goto("data:text/html,<title>Effect</title>");
+ *     expect(yield* page.title).toBe("Effect");
+ *   }),
+ * );
+ * ```
+ *
+ * @see https://playwright.dev/docs/test-fixtures
+ * @since 0.6.0
+ */
+export type EffectTestFunction<Args extends object, A, E> = (
+  args: Args,
+  testInfo: TestInfo,
+) => Effect.Effect<A, E, PlaywrightTestEnvironment>;
+
+/**
+ * Registers Effect-based Playwright tests.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from "effect";
+ * import { PlaywrightPage } from "effect-playwright";
+ * import { expect, test } from "effect-playwright/test";
+ *
+ * test.effect("loads a page", () =>
+ *   Effect.gen(function* () {
+ *     const page = yield* PlaywrightPage;
+ *     yield* page.goto("data:text/html,<title>Effect</title>");
+ *     expect(yield* page.title).toBe("Effect");
+ *   }),
+ * );
+ * ```
+ *
+ * @see https://playwright.dev/docs/test-fixtures
+ * @since 0.6.0
+ */
+export interface EffectTest<Args extends object> {
+  <A, E>(title: string, body: EffectTestFunction<Args, A, E>): void;
+  <A, E>(
+    title: string,
+    details: TestDetails,
+    body: EffectTestFunction<Args, A, E>,
+  ): void;
+}
+
+/**
+ * Effect-based Playwright test registration and modifiers.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from "effect";
+ * import { PlaywrightPage } from "effect-playwright";
+ * import { expect, test } from "effect-playwright/test";
+ *
+ * test.effect("loads a page", () =>
+ *   Effect.gen(function* () {
+ *     const page = yield* PlaywrightPage;
+ *     yield* page.goto("data:text/html,<title>Effect</title>");
+ *     expect(yield* page.title).toBe("Effect");
+ *   }),
+ * );
+ * ```
+ *
+ * @see https://playwright.dev/docs/test-annotations
+ * @since 0.6.0
+ */
+export interface EffectTester<Args extends object> extends EffectTest<Args> {
+  readonly only: EffectTest<Args>;
+  readonly skip: EffectTest<Args>;
+  readonly fixme: EffectTest<Args>;
+  readonly fail: EffectTest<Args> & { readonly only: EffectTest<Args> };
+}
+
+/**
+ * A Playwright `TestType` enhanced with Effect-based registration methods.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from "effect";
+ * import { PlaywrightPage } from "effect-playwright";
+ * import { expect, test } from "effect-playwright/test";
+ *
+ * test.effect("loads a page", () =>
+ *   Effect.gen(function* () {
+ *     const page = yield* PlaywrightPage;
+ *     yield* page.goto("data:text/html,<title>Effect</title>");
+ *     expect(yield* page.title).toBe("Effect");
+ *   }),
+ * );
+ * ```
+ *
+ * @see https://playwright.dev/docs/test-fixtures
+ * @since 0.6.0
+ */
+export type PlaywrightTestMethods<
+  T extends object,
+  W extends object,
+> = TestType<T, W> & { readonly effect: EffectTester<T & W> };
+
+interface EffectRunner {
+  readonly abortController: AbortController;
+  readonly context: Context.Context<
+    Exclude<PlaywrightTestEnvironment, Scope.Scope>
+  >;
+  readonly running: Set<Promise<unknown>>;
+  closed: boolean;
+}
+
+interface InternalFixtures {
+  readonly _effectPlaywrightRuntime: EffectRunner;
+}
+
+const activeRunners = new WeakMap<TestInfo, EffectRunner>();
+const augmentedTesters = new WeakMap<object, EffectTester<object>>();
+const noActiveRuntimeMessage =
+  "effect-playwright/test: no active Effect runtime for this test";
+
+const runPromise = <A, E>(
+  effect: Effect.Effect<A, E>,
+  signal: AbortSignal,
+): Promise<A> =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(effect);
+      if (Exit.isFailure(exit)) {
+        const errors = Cause.prettyErrors(exit.cause);
+        yield* Effect.forEach(errors, (e) => {
+          console.error(e);
+          return Effect.void;
+        });
+      }
+      return yield* exit;
+    }).pipe(Effect.provide(Logger.pretty)),
+    { signal },
+  );
+
+const makeEffectTest = <Args extends object>(
+  register: (
+    title: string,
+    details: TestDetails | undefined,
+    body: (args: Args, testInfo: TestInfo) => Promise<void>,
+  ) => void,
+): EffectTest<Args> => {
+  function effectTest<A, E>(
+    title: string,
+    body: EffectTestFunction<Args, A, E>,
+  ): void;
+  function effectTest<A, E>(
+    title: string,
+    details: TestDetails,
+    body: EffectTestFunction<Args, A, E>,
+  ): void;
+  function effectTest<A, E>(
+    title: string,
+    detailsOrBody: TestDetails | EffectTestFunction<Args, A, E>,
+    possibleBody?: EffectTestFunction<Args, A, E>,
+  ): void {
+    const details =
+      typeof detailsOrBody === "function" ? undefined : detailsOrBody;
+    const body =
+      typeof detailsOrBody === "function" ? detailsOrBody : possibleBody;
+    if (body === undefined) {
+      throw new TypeError("effect-playwright/test: missing Effect test body");
+    }
+
+    const wrapped = (args: Args, testInfo: TestInfo): Promise<void> => {
+      const runner = activeRunners.get(testInfo);
+      if (runner === undefined || runner.closed) {
+        return Promise.reject(new Error(noActiveRuntimeMessage));
+      }
+
+      const program = Effect.suspend(() => body(args, testInfo)).pipe(
+        Effect.provide(runner.context),
+        Effect.scoped,
+        Effect.asVoid,
+      );
+      const promise = runPromise(program, runner.abortController.signal);
+      runner.running.add(promise);
+      void promise.then(
+        () => runner.running.delete(promise),
+        () => runner.running.delete(promise),
+      );
+      return promise;
+    };
+    Object.defineProperty(wrapped, "toString", {
+      value: () => body.toString(),
+    });
+    register(title, details, wrapped);
+  }
+  return effectTest;
+};
+
+type EffectRegistration<Args extends object> = {
+  (
+    title: string,
+    body: (args: Args, testInfo: TestInfo) => Promise<void>,
+  ): void;
+  (
+    title: string,
+    details: TestDetails,
+    body: (args: Args, testInfo: TestInfo) => Promise<void>,
+  ): void;
+};
+
+const makeTester = <Args extends object>(
+  effectTestType: TestType<Args & InternalFixtures, object>,
+): EffectTester<Args> => {
+  const makeRegistration = (
+    method: EffectRegistration<Args & InternalFixtures>,
+  ): EffectTest<Args> =>
+    makeEffectTest((title, details, body) => {
+      if (details === undefined) {
+        method(title, body);
+      } else {
+        method(title, details, body);
+      }
+    });
+
+  const tester = makeRegistration(effectTestType);
+  const fail = makeRegistration(
+    effectTestType.fail,
+  ) as EffectTester<Args>["fail"];
+  Object.defineProperties(fail, {
+    only: { value: makeRegistration(effectTestType.fail.only) },
+  });
+  Object.defineProperties(tester, {
+    only: { value: makeRegistration(effectTestType.only) },
+    skip: { value: makeRegistration(effectTestType.skip) },
+    fixme: { value: makeRegistration(effectTestType.fixme) },
+    fail: { value: fail },
+  });
+  return tester as EffectTester<Args>;
+};
+
+/**
+ * Adds Effect-based test methods to a Playwright `TestType`.
+ *
+ * Call `makeMethods` after `test.extend(...)` or `mergeTests(...)`, because those
+ * APIs return a new `TestType`.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from "effect";
+ * import { PlaywrightPage } from "effect-playwright";
+ * import { expect, test } from "effect-playwright/test";
+ *
+ * test.effect("loads a page", () =>
+ *   Effect.gen(function* () {
+ *     const page = yield* PlaywrightPage;
+ *     yield* page.goto("data:text/html,<title>Effect</title>");
+ *     expect(yield* page.title).toBe("Effect");
+ *   }),
+ * );
+ * ```
+ *
+ * @example
+ * ```ts
+ * import { test as base } from "@playwright/test";
+ * import { Effect } from "effect";
+ * import { expect, makeMethods } from "effect-playwright/test";
+ *
+ * const test = makeMethods(
+ *   base.extend<{ answer: number }>({
+ *     answer: async ({}, use) => use(42),
+ *   }),
+ * );
+ *
+ * test.effect("uses a custom fixture", ({ answer }) =>
+ *   Effect.sync(() => expect(answer).toBe(42)),
+ * );
+ * ```
+ *
+ * @see https://playwright.dev/docs/test-fixtures
+ * @since 0.6.0
+ */
+export const makeMethods: <
+  T extends Pick<PlaywrightTestArgs, "context" | "page">,
+  W extends Pick<PlaywrightWorkerArgs, "browser">,
+>(
+  testType: TestType<T, W>,
+) => PlaywrightTestMethods<T, W> = <
+  T extends Pick<PlaywrightTestArgs, "context" | "page">,
+  W extends Pick<PlaywrightWorkerArgs, "browser">,
+>(
+  testType: TestType<T, W>,
+): PlaywrightTestMethods<T, W> => {
+  const cached = augmentedTesters.get(testType);
+  if (cached !== undefined) {
+    return testType as PlaywrightTestMethods<T, W>;
+  }
+  if (Object.hasOwn(testType, "effect")) {
+    throw new Error(
+      'effect-playwright/test: the supplied TestType already defines "effect"',
+    );
+  }
+
+  const internalFixtures = {
+    _effectPlaywrightRuntime: [
+      async (
+        { browser, context, page }: T & W & InternalFixtures,
+        use: (runner: EffectRunner) => Promise<void>,
+        testInfo: TestInfo,
+      ) => {
+        const runner: EffectRunner = {
+          abortController: new AbortController(),
+          closed: false,
+          context: Context.mergeAll(
+            Context.make(PlaywrightBrowser, PlaywrightBrowser.make(browser)),
+            Context.make(
+              PlaywrightBrowserContext,
+              PlaywrightBrowserContext.make(context),
+            ),
+            Context.make(PlaywrightPage, PlaywrightPage.make(page)),
+          ),
+          running: new Set(),
+        };
+        activeRunners.set(testInfo, runner);
+        try {
+          await use(runner);
+        } finally {
+          runner.closed = true;
+          runner.abortController.abort();
+          await Promise.allSettled([...runner.running]);
+          activeRunners.delete(testInfo);
+        }
+      },
+      { auto: true, box: true, timeout: 0 },
+    ],
+    // biome-ignore lint/complexity/noBannedTypes: Matches Playwright's empty worker fixture type.
+  } as unknown as Fixtures<InternalFixtures, {}, T, W>;
+  const effectTestType = testType.extend<InternalFixtures>(internalFixtures);
+  const tester = makeTester<T & W>(
+    effectTestType as TestType<T & W & InternalFixtures, object>,
+  );
+  augmentedTesters.set(testType, tester as EffectTester<object>);
+  Object.defineProperty(testType, "effect", { value: tester });
+  return testType as PlaywrightTestMethods<T, W>;
+};
+
+/**
+ * The standard Playwright Test API enhanced with `test.effect`.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from "effect";
+ * import { PlaywrightPage } from "effect-playwright";
+ * import { expect, test } from "effect-playwright/test";
+ *
+ * test.effect("loads a page", () =>
+ *   Effect.gen(function* () {
+ *     const page = yield* PlaywrightPage;
+ *     yield* page.goto("data:text/html,<title>Effect</title>");
+ *     expect(yield* page.title).toBe("Effect");
+ *   }),
+ * );
+ * ```
+ *
+ * @see https://playwright.dev/docs/test-fixtures
+ * @since 0.6.0
+ */
+export const test = makeMethods(playwrightTest);
+
+/**
+ * Standalone alias for `test.effect`.
+ *
+ * @example
+ * ```ts
+ * import { Effect } from "effect";
+ * import { PlaywrightPage } from "effect-playwright";
+ * import { expect, test } from "effect-playwright/test";
+ *
+ * test.effect("loads a page", () =>
+ *   Effect.gen(function* () {
+ *     const page = yield* PlaywrightPage;
+ *     yield* page.goto("data:text/html,<title>Effect</title>");
+ *     expect(yield* page.title).toBe("Effect");
+ *   }),
+ * );
+ * ```
+ *
+ * @see https://playwright.dev/docs/test-fixtures
+ * @since 0.6.0
+ */
+export const effect = test.effect;
+
+export default test;

--- a/src/test.ts
+++ b/src/test.ts
@@ -349,10 +349,6 @@ const makeTester = <Args extends object, R>(
   });
   return tester as EffectTester<Args, R>;
 };
-type TestBody<Args extends object> = (
-  args: Args,
-  testInfo: TestInfo,
-) => Promise<void> | void;
 
 const makeLayer = <T extends object, W extends object, R, E>(
   testType: TestType<T, W>,
@@ -373,26 +369,7 @@ const makeLayer = <T extends object, W extends object, R, E>(
   const tester = makeTester<T & W, R>(effectTestType, transform);
 
   const makeLayerMethods = (): LayerTestMethods<T, W, R> => {
-    function layerTest(title: string, body: TestBody<T & W>): void;
-    function layerTest(
-      title: string,
-      details: TestDetails,
-      body: TestBody<T & W>,
-    ): void;
-    function layerTest(
-      title: string,
-      detailsOrBody: TestDetails | TestBody<T & W>,
-      possibleBody?: TestBody<T & W>,
-    ): void {
-      if (typeof detailsOrBody === "function") {
-        testType(title, detailsOrBody);
-      } else if (possibleBody !== undefined) {
-        testType(title, detailsOrBody, possibleBody);
-      } else {
-        throw new TypeError("effect-playwright/test: missing test body");
-      }
-    }
-
+    const layerTest = testType.bind(undefined);
     Object.assign(layerTest, testType);
     const nestedLayer = <R2, E2>(
       nested: Layer.Layer<R2, E2, R>,
@@ -441,8 +418,10 @@ const makeLayer = <T extends object, W extends object, R, E>(
     possibleFunction?: (test: LayerTestMethods<T, W, R>) => void,
   ): void {
     if (typeof nameOrFunction === "function") {
-      registerHooks();
-      nameOrFunction(makeLayerMethods());
+      testType.describe(() => {
+        registerHooks();
+        nameOrFunction(makeLayerMethods());
+      });
       return;
     }
     if (possibleFunction === undefined) {

--- a/src/test.ts
+++ b/src/test.ts
@@ -20,7 +20,16 @@ import {
   type TestInfo,
   type TestType,
 } from "@playwright/test";
-import { Cause, Context, Effect, Exit, Logger, type Scope } from "effect";
+import {
+  Cause,
+  Context,
+  Duration,
+  Effect,
+  Exit,
+  Layer,
+  Logger,
+  Scope,
+} from "effect";
 import { PlaywrightBrowser } from "./browser";
 import { PlaywrightBrowserContext } from "./browser-context";
 import { PlaywrightPage } from "./page";
@@ -75,10 +84,10 @@ export type PlaywrightTestEnvironment =
  * @see https://playwright.dev/docs/test-fixtures
  * @since 0.6.0
  */
-export type EffectTestFunction<Args extends object, A, E> = (
+export type EffectTestFunction<Args extends object, A, E, R = never> = (
   args: Args,
   testInfo: TestInfo,
-) => Effect.Effect<A, E, PlaywrightTestEnvironment>;
+) => Effect.Effect<A, E, PlaywrightTestEnvironment | R>;
 
 /**
  * Registers Effect-based Playwright tests.
@@ -101,12 +110,12 @@ export type EffectTestFunction<Args extends object, A, E> = (
  * @see https://playwright.dev/docs/test-fixtures
  * @since 0.6.0
  */
-export interface EffectTest<Args extends object> {
-  <A, E>(title: string, body: EffectTestFunction<Args, A, E>): void;
+export interface EffectTest<Args extends object, R = never> {
+  <A, E>(title: string, body: EffectTestFunction<Args, A, E, R>): void;
   <A, E>(
     title: string,
     details: TestDetails,
-    body: EffectTestFunction<Args, A, E>,
+    body: EffectTestFunction<Args, A, E, R>,
   ): void;
 }
 
@@ -131,12 +140,44 @@ export interface EffectTest<Args extends object> {
  * @see https://playwright.dev/docs/test-annotations
  * @since 0.6.0
  */
-export interface EffectTester<Args extends object> extends EffectTest<Args> {
-  readonly only: EffectTest<Args>;
-  readonly skip: EffectTest<Args>;
-  readonly fixme: EffectTest<Args>;
-  readonly fail: EffectTest<Args> & { readonly only: EffectTest<Args> };
+export interface EffectTester<Args extends object, R = never>
+  extends EffectTest<Args, R> {
+  readonly only: EffectTest<Args, R>;
+  readonly skip: EffectTest<Args, R>;
+  readonly fixme: EffectTest<Args, R>;
+  readonly fail: EffectTest<Args, R> & { readonly only: EffectTest<Args, R> };
 }
+
+interface LayerOptions {
+  readonly memoMap?: Layer.MemoMap;
+  readonly timeout?: Duration.DurationInput;
+}
+
+interface NestedLayerOptions {
+  readonly timeout?: Duration.DurationInput;
+}
+
+interface LayerRegistration<T extends object, W extends object, R> {
+  (f: (test: LayerTestMethods<T, W, R>) => void): void;
+  (name: string, f: (test: LayerTestMethods<T, W, R>) => void): void;
+}
+
+type LayerTestMethods<T extends object, W extends object, R> = TestType<
+  T,
+  W
+> & {
+  readonly effect: EffectTester<T & W, R>;
+  readonly scoped: EffectTester<T & W, R>;
+  readonly layer: <R2, E>(
+    layer: Layer.Layer<R2, E, R>,
+    options?: NestedLayerOptions,
+  ) => LayerRegistration<T, W, R | R2>;
+};
+
+type LayerMethod<T extends object, W extends object> = <R, E>(
+  layer: Layer.Layer<R, E>,
+  options?: LayerOptions,
+) => LayerRegistration<T, W, R>;
 
 /**
  * A Playwright `TestType` enhanced with Effect-based registration methods.
@@ -162,7 +203,10 @@ export interface EffectTester<Args extends object> extends EffectTest<Args> {
 export type PlaywrightTestMethods<
   T extends object,
   W extends object,
-> = TestType<T, W> & { readonly effect: EffectTester<T & W> };
+> = TestType<T, W> & {
+  readonly effect: EffectTester<T & W>;
+  readonly layer: LayerMethod<T, W>;
+};
 
 interface EffectRunner {
   readonly abortController: AbortController;
@@ -184,7 +228,7 @@ const noActiveRuntimeMessage =
 
 const runPromise = <A, E>(
   effect: Effect.Effect<A, E>,
-  signal: AbortSignal,
+  signal?: AbortSignal,
 ): Promise<A> =>
   Effect.runPromise(
     Effect.gen(function* () {
@@ -201,26 +245,33 @@ const runPromise = <A, E>(
     { signal },
   );
 
-const makeEffectTest = <Args extends object>(
+type EffectTransform<R> = <A, E>(
+  effect: Effect.Effect<A, E, PlaywrightTestEnvironment | R>,
+) => Effect.Effect<A, E, PlaywrightTestEnvironment>;
+
+const withoutLayer: EffectTransform<never> = (effect) => effect;
+
+const makeEffectTest = <Args extends object, R>(
   register: (
     title: string,
     details: TestDetails | undefined,
     body: (args: Args, testInfo: TestInfo) => Promise<void>,
   ) => void,
-): EffectTest<Args> => {
+  transform: EffectTransform<R>,
+): EffectTest<Args, R> => {
   function effectTest<A, E>(
     title: string,
-    body: EffectTestFunction<Args, A, E>,
+    body: EffectTestFunction<Args, A, E, R>,
   ): void;
   function effectTest<A, E>(
     title: string,
     details: TestDetails,
-    body: EffectTestFunction<Args, A, E>,
+    body: EffectTestFunction<Args, A, E, R>,
   ): void;
   function effectTest<A, E>(
     title: string,
-    detailsOrBody: TestDetails | EffectTestFunction<Args, A, E>,
-    possibleBody?: EffectTestFunction<Args, A, E>,
+    detailsOrBody: TestDetails | EffectTestFunction<Args, A, E, R>,
+    possibleBody?: EffectTestFunction<Args, A, E, R>,
   ): void {
     const details =
       typeof detailsOrBody === "function" ? undefined : detailsOrBody;
@@ -236,11 +287,9 @@ const makeEffectTest = <Args extends object>(
         return Promise.reject(new Error(noActiveRuntimeMessage));
       }
 
-      const program = Effect.suspend(() => body(args, testInfo)).pipe(
-        Effect.provide(runner.context),
-        Effect.scoped,
-        Effect.asVoid,
-      );
+      const program = transform(
+        Effect.suspend(() => body(args, testInfo)),
+      ).pipe(Effect.provide(runner.context), Effect.scoped, Effect.asVoid);
       const promise = runPromise(program, runner.abortController.signal);
       runner.running.add(promise);
       void promise.then(
@@ -269,24 +318,26 @@ type EffectRegistration<Args extends object> = {
   ): void;
 };
 
-const makeTester = <Args extends object>(
+const makeTester = <Args extends object, R>(
   effectTestType: TestType<Args & InternalFixtures, object>,
-): EffectTester<Args> => {
+  transform: EffectTransform<R>,
+): EffectTester<Args, R> => {
   const makeRegistration = (
     method: EffectRegistration<Args & InternalFixtures>,
-  ): EffectTest<Args> =>
+  ): EffectTest<Args, R> =>
     makeEffectTest((title, details, body) => {
       if (details === undefined) {
         method(title, body);
       } else {
         method(title, details, body);
       }
-    });
+    }, transform);
 
   const tester = makeRegistration(effectTestType);
-  const fail = makeRegistration(
-    effectTestType.fail,
-  ) as EffectTester<Args>["fail"];
+  const fail = makeRegistration(effectTestType.fail) as EffectTester<
+    Args,
+    R
+  >["fail"];
   Object.defineProperties(fail, {
     only: { value: makeRegistration(effectTestType.fail.only) },
   });
@@ -296,7 +347,114 @@ const makeTester = <Args extends object>(
     fixme: { value: makeRegistration(effectTestType.fixme) },
     fail: { value: fail },
   });
-  return tester as EffectTester<Args>;
+  return tester as EffectTester<Args, R>;
+};
+type TestBody<Args extends object> = (
+  args: Args,
+  testInfo: TestInfo,
+) => Promise<void> | void;
+
+const makeLayer = <T extends object, W extends object, R, E>(
+  testType: TestType<T, W>,
+  effectTestType: TestType<T & W & InternalFixtures, object>,
+  layer: Layer.Layer<R, E>,
+  options?: LayerOptions,
+): LayerRegistration<T, W, R> => {
+  const memoMap = options?.memoMap ?? Effect.runSync(Layer.makeMemoMap);
+  const scope = Effect.runSync(Scope.make());
+  const runtimeEffect = Layer.toRuntimeWithMemoMap(layer, memoMap).pipe(
+    Scope.extend(scope),
+    Effect.orDie,
+    Effect.cached,
+    Effect.runSync,
+  );
+  const transform: EffectTransform<R> = (effect) =>
+    Effect.flatMap(runtimeEffect, (runtime) => Effect.provide(effect, runtime));
+  const tester = makeTester<T & W, R>(effectTestType, transform);
+
+  const makeLayerMethods = (): LayerTestMethods<T, W, R> => {
+    function layerTest(title: string, body: TestBody<T & W>): void;
+    function layerTest(
+      title: string,
+      details: TestDetails,
+      body: TestBody<T & W>,
+    ): void;
+    function layerTest(
+      title: string,
+      detailsOrBody: TestDetails | TestBody<T & W>,
+      possibleBody?: TestBody<T & W>,
+    ): void {
+      if (typeof detailsOrBody === "function") {
+        testType(title, detailsOrBody);
+      } else if (possibleBody !== undefined) {
+        testType(title, detailsOrBody, possibleBody);
+      } else {
+        throw new TypeError("effect-playwright/test: missing test body");
+      }
+    }
+
+    Object.assign(layerTest, testType);
+    const nestedLayer = <R2, E2>(
+      nested: Layer.Layer<R2, E2, R>,
+      nestedOptions?: NestedLayerOptions,
+    ): LayerRegistration<T, W, R | R2> =>
+      makeLayer(testType, effectTestType, Layer.provideMerge(nested, layer), {
+        memoMap,
+        timeout: nestedOptions?.timeout,
+      });
+    Object.defineProperties(layerTest, {
+      effect: { value: tester },
+      layer: { value: nestedLayer },
+      scoped: { value: tester },
+    });
+    return layerTest as LayerTestMethods<T, W, R>;
+  };
+
+  const registerHooks = (): void => {
+    testType.beforeAll(
+      // biome-ignore lint/correctness/noEmptyPattern: Playwright requires fixture object destructuring.
+      async ({}, testInfo) => {
+        if (options?.timeout !== undefined) {
+          testInfo.setTimeout(Duration.toMillis(options.timeout));
+        }
+        await runPromise(Effect.asVoid(runtimeEffect));
+      },
+    );
+    testType.afterAll(
+      // biome-ignore lint/correctness/noEmptyPattern: Playwright requires fixture object destructuring.
+      async ({}, testInfo) => {
+        if (options?.timeout !== undefined) {
+          testInfo.setTimeout(Duration.toMillis(options.timeout));
+        }
+        await runPromise(Scope.close(scope, Exit.void));
+      },
+    );
+  };
+
+  function register(f: (test: LayerTestMethods<T, W, R>) => void): void;
+  function register(
+    name: string,
+    f: (test: LayerTestMethods<T, W, R>) => void,
+  ): void;
+  function register(
+    nameOrFunction: string | ((test: LayerTestMethods<T, W, R>) => void),
+    possibleFunction?: (test: LayerTestMethods<T, W, R>) => void,
+  ): void {
+    if (typeof nameOrFunction === "function") {
+      registerHooks();
+      nameOrFunction(makeLayerMethods());
+      return;
+    }
+    if (possibleFunction === undefined) {
+      throw new TypeError("effect-playwright/test: missing layer test body");
+    }
+    testType.describe(nameOrFunction, () => {
+      registerHooks();
+      possibleFunction(makeLayerMethods());
+    });
+  }
+
+  return register;
 };
 
 /**
@@ -355,9 +513,10 @@ export const makeMethods: <
   if (cached !== undefined) {
     return testType as PlaywrightTestMethods<T, W>;
   }
-  if (Object.hasOwn(testType, "effect")) {
+  if (Object.hasOwn(testType, "effect") || Object.hasOwn(testType, "layer")) {
+    const method = Object.hasOwn(testType, "effect") ? "effect" : "layer";
     throw new Error(
-      'effect-playwright/test: the supplied TestType already defines "effect"',
+      `effect-playwright/test: the supplied TestType already defines "${method}"`,
     );
   }
 
@@ -396,16 +555,23 @@ export const makeMethods: <
     // biome-ignore lint/complexity/noBannedTypes: Matches Playwright's empty worker fixture type.
   } as unknown as Fixtures<InternalFixtures, {}, T, W>;
   const effectTestType = testType.extend<InternalFixtures>(internalFixtures);
-  const tester = makeTester<T & W>(
-    effectTestType as TestType<T & W & InternalFixtures, object>,
-  );
+  const typedEffectTestType = effectTestType as TestType<
+    T & W & InternalFixtures,
+    object
+  >;
+  const tester = makeTester<T & W, never>(typedEffectTestType, withoutLayer);
+  const layerMethod: LayerMethod<T, W> = (layer, options) =>
+    makeLayer(testType, typedEffectTestType, layer, options);
   augmentedTesters.set(testType, tester as EffectTester<object>);
-  Object.defineProperty(testType, "effect", { value: tester });
+  Object.defineProperties(testType, {
+    effect: { value: tester },
+    layer: { value: layerMethod },
+  });
   return testType as PlaywrightTestMethods<T, W>;
 };
 
 /**
- * The standard Playwright Test API enhanced with `test.effect`.
+ * The standard Playwright Test API enhanced with Effect test and layer methods.
  *
  * @example
  * ```ts
@@ -426,6 +592,35 @@ export const makeMethods: <
  * @since 0.6.0
  */
 export const test = makeMethods(playwrightTest);
+
+/**
+ * Shares an Effect `Layer` between Playwright tests in the current worker.
+ *
+ * The layer is acquired before the tests in the block and released after all
+ * tests in the block finish. Passing a name wraps the tests in a Playwright
+ * `describe` block. Layers can be nested and reuse their parent services.
+ *
+ * @example
+ * ```ts
+ * import { Context, Effect, Layer } from "effect";
+ * import { expect, layer } from "effect-playwright/test";
+ *
+ * class Greeting extends Context.Tag("Greeting")<Greeting, string>() {}
+ *
+ * layer(Layer.succeed(Greeting, "hello"))("Greeting", (it) => {
+ *   it.effect("provides the layer", () =>
+ *     Effect.gen(function* () {
+ *       expect(yield* Greeting).toBe("hello");
+ *     }),
+ *   );
+ * });
+ * ```
+ *
+ * @see https://playwright.dev/docs/api/class-test#test-before-all
+ * @since 0.6.0
+ */
+export const layer: LayerMethod<PlaywrightTestArgs, PlaywrightWorkerArgs> =
+  test.layer;
 
 /**
  * Standalone alias for `test.effect`.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "types": ["vitest/importMeta", "node"],
     "paths": {
       "effect-playwright": ["./src/index.ts"],
-      "effect-playwright/experimental": ["./src/experimental/index.ts"]
+      "effect-playwright/experimental": ["./src/experimental/index.ts"],
+      "effect-playwright/test": ["./src/test.ts"]
     },
     "plugins": [
       {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/experimental/index.ts"],
+  entry: ["src/index.ts", "src/experimental/index.ts", "src/test.ts"],
   exports: true,
   dts: true,
   define: {

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": ["./src/index.ts", "./src/experimental/index.ts"],
+  "entryPoints": [
+    "./src/index.ts",
+    "./src/experimental/index.ts",
+    "./src/test.ts"
+  ],
   "out": "docs",
   "plugin": [],
   "navigation": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New public test-runner integration with non-trivial fixture, layer lifecycle, and timeout/teardown behavior; impact is limited by the optional peer and dedicated integration tests rather than core automation APIs.
> 
> **Overview**
> Adds a new **`effect-playwright/test`** entry that wraps **`@playwright/test`** so suites can run **Effect** programs with **`test.effect`**, scoped finalizers, and the existing **`PlaywrightBrowser` / `PlaywrightBrowserContext` / `PlaywrightPage`** services injected from Playwright fixtures.
> 
> **`layer`** and **`test.layer`** acquire an Effect **`Layer`** once per worker (with nesting, shared memoization, and **`beforeAll`/`afterAll`** lifecycle), and **`makeMethods`** attaches the same APIs to custom **`TestType`** instances after **`extend`**. **`@playwright/test`** is an **optional** peer; CI gains **`pnpm test:playwright`** on **`src/test.spec.ts`**, plus README/Changelog and build/docs wiring for the new export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ec9571557202e4e54ccf45ff709843df699e62c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->