### PR TITLE
Upgrade Playwright to 1.62.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,11 +46,11 @@
   ],
   "packageManager": "pnpm@11.5.1",
   "dependencies": {
-    "playwright-core": "^1.60.0"
+    "playwright-core": "^1.62.1"
   },
   "peerDependencies": {
     "@effect/platform": "^0.93.3",
-    "@playwright/test": "^1.60.0",
+    "@playwright/test": "^1.62.1",
     "effect": "^3.19.6"
   },
   "peerDependenciesMeta": {
@@ -65,10 +65,10 @@
     "@effect/platform": "^0.96.1",
     "@effect/platform-node": "^0.107.0",
     "@effect/vitest": "^0.29.0",
-    "@playwright/test": "^1.60.0",
+    "@playwright/test": "^1.62.1",
     "@types/node": "^25.9.1",
     "effect": "^3.21.2",
-    "playwright": "^1.60.0",
+    "playwright": "^1.62.1",
     "ts-morph": "^28.0.0",
     "tsdown": "0.22.1",
     "tsx": "^4.22.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       playwright-core:
-        specifier: ^1.60.0
-        version: 1.60.0
+        specifier: ^1.62.1
+        version: 1.62.1
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.16
@@ -31,8 +31,8 @@ importers:
         specifier: ^0.29.0
         version: 0.29.0(effect@3.21.2)(vitest@4.1.8(@types/node@25.9.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0)))
       '@playwright/test':
-        specifier: ^1.60.0
-        version: 1.60.0
+        specifier: ^1.62.1
+        version: 1.62.1
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
@@ -40,8 +40,8 @@ importers:
         specifier: ^3.21.2
         version: 3.21.2
       playwright:
-        specifier: ^1.60.0
-        version: 1.60.0
+        specifier: ^1.62.1
+        version: 1.62.1
       ts-morph:
         specifier: ^28.0.0
         version: 28.0.0
@@ -553,9 +553,9 @@ packages:
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
 
-  '@playwright/test@1.60.0':
-    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
-    engines: {node: '>=18'}
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
     hasBin: true
 
   '@quansync/fs@1.0.0':
@@ -1009,14 +1009,14 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  playwright-core@1.60.0:
-    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
-    engines: {node: '>=18'}
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
     hasBin: true
 
-  playwright@1.60.0:
-    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
-    engines: {node: '>=18'}
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
     hasBin: true
 
   postcss@8.5.15:
@@ -1645,9 +1645,9 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
 
-  '@playwright/test@1.60.0':
+  '@playwright/test@1.62.1':
     dependencies:
-      playwright: 1.60.0
+      playwright: 1.62.1
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -2028,11 +2028,11 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  playwright-core@1.60.0: {}
+  playwright-core@1.62.1: {}
 
-  playwright@1.60.0:
+  playwright@1.62.1:
     dependencies:
-      playwright-core: 1.60.0
+      playwright-core: 1.62.1
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/src/browser-context.test.ts
+++ b/src/browser-context.test.ts
@@ -73,9 +73,13 @@ layer(PlaywrightEnvironment.layer(chromium))(
         const browser = yield* PlaywrightBrowser;
         const context = yield* browser.newContext();
 
-        yield* context.addInitScript(() => {
-          (window as TestWindow).magicValue = 84;
-        });
+        yield* context.addInitScript(
+          async (double: (value: number) => Promise<number>) => {
+            (window as TestWindow).magicValue = await double(42);
+          },
+          async (value: number) => value * 2,
+          { exposeFunctions: true },
+        );
 
         const page1 = yield* context.newPage;
         yield* page1.goto("about:blank");
@@ -106,6 +110,30 @@ layer(PlaywrightEnvironment.layer(chromium))(
 
           assert.strictEqual(context.isClosed(), true);
         }).pipe(PlaywrightEnvironment.withBrowser),
+    );
+    it.scoped("credentials should create, get, and delete credentials", () =>
+      Effect.gen(function* () {
+        const browser = yield* PlaywrightBrowser;
+        const context = yield* browser.newContext();
+
+        yield* context.credentials.install;
+
+        const created = yield* context.credentials.create("example.test");
+        assert.strictEqual(created.rpId, "example.test");
+
+        const credentials = yield* context.credentials.get({
+          id: created.id,
+        });
+        assert.strictEqual(credentials.length, 1);
+        assert.deepStrictEqual(credentials[0], created);
+
+        yield* context.credentials.delete(created.id);
+
+        const afterDelete = yield* context.credentials.get({
+          id: created.id,
+        });
+        assert.strictEqual(afterDelete.length, 0);
+      }).pipe(PlaywrightEnvironment.withBrowser),
     );
   },
 );

--- a/src/browser-context.ts
+++ b/src/browser-context.ts
@@ -20,10 +20,14 @@ import {
   PlaywrightResponse,
   PlaywrightWorker,
 } from "./common";
+import {
+  PlaywrightCredentials,
+  type PlaywrightCredentialsService,
+} from "./credentials";
 import type { PlaywrightError } from "./errors";
 import { PlaywrightFrame } from "./frame";
 import { PlaywrightPage } from "./page";
-import type { PatchedEvents } from "./playwright-types";
+import type { PageFunction, PatchedEvents } from "./playwright-types";
 import { PlaywrightTracing, type PlaywrightTracingService } from "./tracing";
 import { useHelper } from "./utils";
 
@@ -83,6 +87,13 @@ export interface PlaywrightBrowserContextService {
    */
   readonly clock: PlaywrightClockService;
   /**
+   * Access the virtual WebAuthn credentials manager.
+   *
+   * @see {@link BrowserContext.credentials}
+   * @since 0.5.1
+   */
+  readonly credentials: PlaywrightCredentialsService;
+  /**
    * Access the tracing.
    *
    * @since 0.5.0
@@ -132,9 +143,10 @@ export interface PlaywrightBrowserContextService {
    * @see {@link BrowserContext.addInitScript}
    * @since 0.2.0
    */
-  readonly addInitScript: (
-    script: Parameters<BrowserContext["addInitScript"]>[0],
-    arg?: Parameters<BrowserContext["addInitScript"]>[1],
+  readonly addInitScript: <Arg>(
+    script: PageFunction<Arg, unknown> | { path?: string; content?: string },
+    arg?: Arg,
+    options?: Parameters<BrowserContext["addInitScript"]>[2],
   ) => Effect.Effect<void, PlaywrightError>;
 
   /**
@@ -304,12 +316,26 @@ export class PlaywrightBrowserContext extends Context.Tag(
     const use = useHelper(context);
     return PlaywrightBrowserContext.of({
       clock: PlaywrightClock.make(context.clock),
+      credentials: PlaywrightCredentials.make(context.credentials),
       tracing: PlaywrightTracing.make(context.tracing),
       pages: () => context.pages().map(PlaywrightPage.make),
       newPage: use((c) => c.newPage().then(PlaywrightPage.make)),
       close: use((c) => c.close()),
       isClosed: () => context.isClosed(),
-      addInitScript: (script, arg) => use((c) => c.addInitScript(script, arg)),
+      addInitScript: <Arg>(
+        script:
+          | PageFunction<Arg, unknown>
+          | { path?: string; content?: string },
+        arg?: Arg,
+        options?: Parameters<BrowserContext["addInitScript"]>[2],
+      ) =>
+        use((c) =>
+          c.addInitScript<Arg>(
+            script as unknown as Parameters<typeof c.addInitScript<Arg>>[0],
+            arg,
+            options,
+          ),
+        ).pipe(Effect.asVoid),
       browser: () =>
         Option.fromNullable(context.browser()).pipe(
           Option.map(PlaywrightBrowser.make),

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -1,0 +1,99 @@
+import { Context, type Effect } from "effect";
+import type { Credentials } from "playwright-core";
+import type { PlaywrightError } from "./errors";
+import { useHelper } from "./utils";
+
+/**
+ * @example
+ * ```ts
+ * import { Effect } from "effect";
+ * import { PlaywrightBrowser } from "effect-playwright";
+ *
+ * const program = Effect.gen(function* () {
+ *   const browser = yield* PlaywrightBrowser;
+ *   const context = yield* browser.newContext();
+ *   yield* context.credentials.install;
+ *   const credential = yield* context.credentials.create("example.com");
+ *   const credentials = yield* context.credentials.get({ id: credential.id });
+ *   yield* context.credentials.delete(credential.id);
+ *   return credentials;
+ * });
+ * ```
+ *
+ * @category model
+ * @since 0.5.1
+ */
+export interface PlaywrightCredentialsService {
+  /**
+   * Installs the virtual WebAuthn authenticator into the browser context.
+   *
+   * @see {@link Credentials.install}
+   * @since 0.5.1
+   */
+  readonly install: Effect.Effect<
+    Awaited<ReturnType<Credentials["install"]>>,
+    PlaywrightError
+  >;
+
+  /**
+   * Seeds a virtual WebAuthn credential and returns it.
+   *
+   * @see {@link Credentials.create}
+   * @since 0.5.1
+   */
+  readonly create: (
+    rpId: Parameters<Credentials["create"]>[0],
+    options?: Parameters<Credentials["create"]>[1],
+  ) => Effect.Effect<
+    Awaited<ReturnType<Credentials["create"]>>,
+    PlaywrightError
+  >;
+
+  /**
+   * Returns credentials currently held by the virtual authenticator.
+   *
+   * @see {@link Credentials.get}
+   * @since 0.5.1
+   */
+  readonly get: (
+    options?: Parameters<Credentials["get"]>[0],
+  ) => Effect.Effect<Awaited<ReturnType<Credentials["get"]>>, PlaywrightError>;
+
+  /**
+   * Removes a credential from the virtual authenticator.
+   *
+   * @see {@link Credentials.delete}
+   * @since 0.5.1
+   */
+  readonly delete: (
+    id: Parameters<Credentials["delete"]>[0],
+  ) => Effect.Effect<
+    Awaited<ReturnType<Credentials["delete"]>>,
+    PlaywrightError
+  >;
+}
+
+/**
+ * @category tag
+ * @since 0.5.1
+ */
+export class PlaywrightCredentials extends Context.Tag(
+  "effect-playwright/PlaywrightCredentials",
+)<PlaywrightCredentials, PlaywrightCredentialsService>() {
+  /**
+   * Creates a `PlaywrightCredentials` from a Playwright `Credentials` instance.
+   *
+   * @category constructor
+   * @since 0.5.1
+   */
+  static make(credentials: Credentials): PlaywrightCredentialsService {
+    const use = useHelper(credentials);
+
+    return PlaywrightCredentials.of({
+      install: use((c) => c.install()),
+      create: (rpId, options) => use((c) => c.create(rpId, options)),
+      get: (options) => use((c) => c.get(options)),
+      delete: (id) => use((c) => c.delete(id)),
+    });
+  }
+}

--- a/src/frame.test.ts
+++ b/src/frame.test.ts
@@ -111,7 +111,7 @@ layer(PlaywrightEnvironment.layer(chromium))("PlaywrightFrame", (it) => {
       const frameEl = yield* frame.frameElement;
       assert.isOk(frameEl, "Frame element not found");
       const tagName = yield* Effect.promise(() =>
-        frameEl.evaluate((el) => (el as any).tagName),
+        frameEl.evaluate((el) => (el as Element).tagName),
       );
       assert.strictEqual(tagName, "IFRAME");
 
@@ -120,6 +120,25 @@ layer(PlaywrightEnvironment.layer(chromium))("PlaywrightFrame", (it) => {
       const newContent = yield* frame.content;
       assert.isTrue(newContent.includes("New Content"));
     }).pipe(PlaywrightEnvironment.withBrowser),
+  );
+
+  it.scoped(
+    "evaluate should expose a function-valued argument in the frame context",
+    () =>
+      Effect.gen(function* () {
+        const browser = yield* PlaywrightBrowser;
+        const page = yield* browser.newPage();
+        const frame = page.mainFrame();
+
+        const result = yield* frame.evaluate(
+          async (triple: (value: number) => Promise<number>) =>
+            await triple(14),
+          async (value: number) => value * 3,
+          { exposeFunctions: true },
+        );
+
+        assert.strictEqual(result, 42);
+      }).pipe(PlaywrightEnvironment.withBrowser),
   );
 
   it.scoped("waitForLoadState should resolve on frame", () =>

--- a/src/frame.ts
+++ b/src/frame.ts
@@ -50,6 +50,7 @@ export interface PlaywrightFrameService {
   readonly evaluate: <R, Arg = void>(
     pageFunction: PageFunction<Arg, R>,
     arg?: Arg,
+    options?: Parameters<Frame["evaluate"]>[2],
   ) => Effect.Effect<R, PlaywrightError>;
   /**
    * Returns the frame title.
@@ -273,8 +274,18 @@ export class PlaywrightFrame extends Context.Tag(
       waitForURL: (url, options) => use((f) => f.waitForURL(url, options)),
       waitForLoadState: (state, options) =>
         use((f) => f.waitForLoadState(state, options)),
-      evaluate: <R, Arg>(f: PageFunction<Arg, R>, arg?: Arg) =>
-        use((frame) => frame.evaluate<R, Arg>(f, arg as Arg)),
+      evaluate: <R, Arg>(
+        f: PageFunction<Arg, R>,
+        arg?: Arg,
+        options?: Parameters<Frame["evaluate"]>[2],
+      ) =>
+        use((frame) =>
+          frame.evaluate<R, Arg>(
+            f as unknown as Parameters<typeof frame.evaluate<R, Arg>>[0],
+            arg as Arg,
+            options,
+          ),
+        ),
       title: use((f) => f.title()),
       use,
       locator: (selector, options) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export {
 } from "./browser-context";
 export * from "./clock";
 export * from "./common";
+export * from "./credentials";
 export type { PlaywrightErrorReason } from "./errors";
 export { PlaywrightError } from "./errors";
 export * from "./frame";
@@ -30,3 +31,4 @@ export * from "./mouse";
 export * from "./page";
 export * from "./playwright";
 export * from "./touchscreen";
+export * from "./web-storage";

--- a/src/locator.test.ts
+++ b/src/locator.test.ts
@@ -69,6 +69,55 @@ layer(PlaywrightEnvironment.layer(chromium))("PlaywrightLocator", (it) => {
     }).pipe(PlaywrightEnvironment.withBrowser),
   );
 
+  it.scoped("waitForFunction", () =>
+    Effect.gen(function* () {
+      const browser = yield* PlaywrightBrowser;
+      const page = yield* browser.newPage();
+      yield* page.setContent('<div id="status">Pending</div>');
+
+      const status = page.locator("#status");
+      const result = yield* status.waitForFunction((element, expected) => {
+        if (!element.hasAttribute("data-update-scheduled")) {
+          element.setAttribute("data-update-scheduled", "true");
+          queueMicrotask(() => {
+            element.textContent = expected;
+          });
+          return false;
+        }
+        return element.textContent === expected;
+      }, "Ready");
+
+      assert(result === undefined);
+      assert((yield* status.textContent()) === "Ready");
+    }).pipe(PlaywrightEnvironment.withBrowser),
+  );
+
+  it.scoped("evaluate options expose function arguments", () =>
+    Effect.gen(function* () {
+      const browser = yield* PlaywrightBrowser;
+      const page = yield* browser.newPage();
+      yield* page.setContent('<div id="message">hello</div>');
+
+      const message = page.locator("#message");
+      const evaluated = yield* message.evaluate(
+        async (element, transform) =>
+          transform(element.textContent ?? "missing"),
+        (value: string) => `evaluated:${value}`,
+        { exposeFunctions: true },
+      );
+      assert(evaluated === "evaluated:hello");
+
+      const handle = yield* message.evaluateHandle(
+        async (element, transform) =>
+          transform(element.textContent ?? "missing"),
+        (value: string) => `handled:${value}`,
+        { exposeFunctions: true },
+      );
+      const handled = yield* Effect.promise(() => handle.jsonValue());
+      assert(handled === "handled:hello");
+    }).pipe(PlaywrightEnvironment.withBrowser),
+  );
+
   it.scoped("kitchensink", () =>
     Effect.gen(function* () {
       const browser = yield* PlaywrightBrowser;

--- a/src/locator.ts
+++ b/src/locator.ts
@@ -318,6 +318,42 @@ export interface PlaywrightLocatorService {
     options?: Parameters<Locator["waitFor"]>[0],
   ) => Effect.Effect<void, PlaywrightError>;
   /**
+   * Returns when the matched element satisfies the provided predicate.
+   *
+   * @example
+   * ```ts
+   * import { chromium } from "@playwright/test";
+   * import { Effect } from "effect";
+   * import { PlaywrightBrowser } from "effect-playwright";
+   * import { PlaywrightEnvironment } from "effect-playwright/experimental";
+   *
+   * const program = Effect.gen(function* () {
+   *   const browser = yield* PlaywrightBrowser;
+   *   const page = yield* browser.newPage();
+   *   yield* page.setContent('<div id="status">Ready</div>');
+   *   yield* page.locator("#status").waitForFunction(
+   *     (element, expected) => element.textContent === expected,
+   *     "Ready",
+   *   );
+   * }).pipe(
+   *   PlaywrightEnvironment.provideBrowser,
+   *   Effect.provide(PlaywrightEnvironment.layer(chromium)),
+   * );
+   * ```
+   *
+   * @see {@link Locator.waitForFunction}
+   * @since 0.5.1
+   */
+  readonly waitForFunction: <
+    R,
+    Arg = void,
+    E extends SVGElement | HTMLElement = SVGElement | HTMLElement,
+  >(
+    pageFunction: (element: E, arg: Unboxed<Arg>) => R | Promise<R>,
+    arg?: Arg,
+    options?: Parameters<Locator["waitForFunction"]>[2],
+  ) => Effect.Effect<void, PlaywrightError>;
+  /**
    * Evaluates a function on the matched element.
    *
    * @example
@@ -345,7 +381,7 @@ export interface PlaywrightLocatorService {
   >(
     pageFunction: (element: E, arg: Unboxed<Arg>) => R | Promise<R>,
     arg?: Arg,
-    options?: { timeout?: number },
+    options?: Parameters<Locator["evaluate"]>[2],
   ) => Effect.Effect<R, PlaywrightError>;
   /**
    * Highlights the corresponding element(s) on the screen.
@@ -426,6 +462,7 @@ export interface PlaywrightLocatorService {
   >(
     pageFunction: (element: E, arg: Unboxed<Arg>) => R | Promise<R>,
     arg?: Arg,
+    options?: Parameters<Locator["evaluateHandle"]>[2],
   ) => Effect.Effect<JSHandle<R>, PlaywrightError>;
   /**
    * Resolves given locator to the first matching DOM element.
@@ -771,6 +808,24 @@ export class PlaywrightLocator extends Context.Tag(
       isHidden: (options) => use((l) => l.isHidden(options)),
       isVisible: (options) => use((l) => l.isVisible(options)),
       waitFor: (options) => use((l) => l.waitFor(options)),
+      waitForFunction: <
+        R,
+        Arg = void,
+        E extends SVGElement | HTMLElement = SVGElement | HTMLElement,
+      >(
+        pageFunction: (element: E, arg: Unboxed<Arg>) => R | Promise<R>,
+        arg?: Arg,
+        options?: Parameters<Locator["waitForFunction"]>[2],
+      ) =>
+        use((l) =>
+          l.waitForFunction<Arg, E>(
+            pageFunction as unknown as Parameters<
+              typeof l.waitForFunction<Arg, E>
+            >[0],
+            arg as Arg,
+            options,
+          ),
+        ),
       evaluate: <
         R,
         Arg = void,
@@ -778,8 +833,17 @@ export class PlaywrightLocator extends Context.Tag(
       >(
         pageFunction: (element: E, arg: Unboxed<Arg>) => R | Promise<R>,
         arg?: Arg,
-        options?: { timeout?: number },
-      ) => use((l) => l.evaluate(pageFunction, arg as Arg, options)),
+        options?: Parameters<Locator["evaluate"]>[2],
+      ) =>
+        use((l) =>
+          l.evaluate<R, Arg, E>(
+            pageFunction as unknown as Parameters<
+              typeof l.evaluate<R, Arg, E>
+            >[0],
+            arg as Arg,
+            options,
+          ),
+        ),
       evaluateAll: <
         R,
         Arg = void,
@@ -787,7 +851,15 @@ export class PlaywrightLocator extends Context.Tag(
       >(
         pageFunction: (elements: E[], arg: Unboxed<Arg>) => R | Promise<R>,
         arg?: Arg,
-      ) => use((l) => l.evaluateAll(pageFunction, arg as Arg)),
+      ) =>
+        use((l) =>
+          l.evaluateAll<R, Arg, E>(
+            pageFunction as unknown as Parameters<
+              typeof l.evaluateAll<R, Arg, E>
+            >[0],
+            arg as Arg,
+          ),
+        ),
       evaluateHandle: <
         R,
         Arg = void,
@@ -795,7 +867,17 @@ export class PlaywrightLocator extends Context.Tag(
       >(
         pageFunction: (element: E, arg: Unboxed<Arg>) => R | Promise<R>,
         arg?: Arg,
-      ) => use((l) => l.evaluateHandle(pageFunction, arg as Arg)),
+        options?: Parameters<Locator["evaluateHandle"]>[2],
+      ) =>
+        use((l) =>
+          l.evaluateHandle<R, Arg, E>(
+            pageFunction as unknown as Parameters<
+              typeof l.evaluateHandle<R, Arg, E>
+            >[0],
+            arg as Arg,
+            options,
+          ),
+        ),
       elementHandle: (options) =>
         use((l) => l.elementHandle(options)).pipe(
           Effect.map(Option.fromNullable),

--- a/src/page.test.ts
+++ b/src/page.test.ts
@@ -129,6 +129,24 @@ layer(PlaywrightEnvironment.layer(chromium))("PlaywrightPage", (it) => {
     }).pipe(PlaywrightEnvironment.withBrowser),
   );
 
+  it.scoped(
+    "evaluate should expose a function-valued argument in the page context",
+    () =>
+      Effect.gen(function* () {
+        const browser = yield* PlaywrightBrowser;
+        const page = yield* browser.newPage();
+
+        const result = yield* page.evaluate(
+          async (double: (value: number) => Promise<number>) =>
+            await double(21),
+          async (value: number) => value * 2,
+          { exposeFunctions: true },
+        );
+
+        assert.strictEqual(result, 42);
+      }).pipe(PlaywrightEnvironment.withBrowser),
+  );
+
   it.scoped("click should work with options", () =>
     Effect.gen(function* () {
       const browser = yield* PlaywrightBrowser;
@@ -394,9 +412,13 @@ layer(PlaywrightEnvironment.layer(chromium))("PlaywrightPage", (it) => {
       const browser = yield* PlaywrightBrowser;
       const page = yield* browser.newPage();
 
-      yield* page.addInitScript(() => {
-        (window as TestWindow).magicValue = 42;
-      });
+      yield* page.addInitScript(
+        async (double: (value: number) => Promise<number>) => {
+          (window as TestWindow).magicValue = await double(21);
+        },
+        async (value: number) => value * 2,
+        { exposeFunctions: true },
+      );
 
       yield* page.goto("about:blank");
 
@@ -934,6 +956,43 @@ layer(PlaywrightEnvironment.layer(chromium))("PlaywrightPage", (it) => {
       const workers = page.workers();
       assert(workers.length >= 1);
       assert.strictEqual(typeof workers[0].url(), "string");
+    }).pipe(PlaywrightEnvironment.withBrowser),
+  );
+  it.scoped("web storage should round-trip items on a page origin", () =>
+    Effect.gen(function* () {
+      const browser = yield* PlaywrightBrowser;
+      const page = yield* browser.newPage();
+
+      yield* page.use((playwrightPage) =>
+        playwrightPage.route("http://storage.test/", (route) =>
+          route.fulfill({ body: "<!doctype html><title>Storage</title>" }),
+        ),
+      );
+      yield* page.goto("http://storage.test/");
+
+      for (const storage of [page.localStorage, page.sessionStorage]) {
+        yield* storage.clear;
+
+        yield* storage.setItem("first", "one");
+        yield* storage.setItem("second", "two");
+
+        const first = yield* storage.getItem("first");
+        assert.deepStrictEqual(first, Option.some("one"));
+
+        const items = yield* storage.items;
+        assert.deepStrictEqual(items, [
+          { name: "first", value: "one" },
+          { name: "second", value: "two" },
+        ]);
+
+        yield* storage.removeItem("first");
+        const removed = yield* storage.getItem("first");
+        assert.isTrue(Option.isNone(removed));
+
+        yield* storage.clear;
+        const afterClear = yield* storage.items;
+        assert.deepStrictEqual(afterClear, []);
+      }
     }).pipe(PlaywrightEnvironment.withBrowser),
   );
 });

--- a/src/page.ts
+++ b/src/page.ts
@@ -48,6 +48,10 @@ import {
   type PlaywrightTouchscreenService,
 } from "./touchscreen";
 import { useHelper } from "./utils";
+import {
+  PlaywrightWebStorage,
+  type PlaywrightWebStorageService,
+} from "./web-storage";
 
 interface PageEvents {
   close: Page;
@@ -108,6 +112,13 @@ export interface PlaywrightPageService {
    */
   readonly clock: PlaywrightClockService;
   /**
+   * Access local storage for the page's current origin.
+   *
+   * @see {@link Page.localStorage}
+   * @since 0.5.1
+   */
+  readonly localStorage: PlaywrightWebStorageService;
+  /**
    * Access the keyboard.
    *
    * @since 0.3.0
@@ -131,6 +142,13 @@ export interface PlaywrightPageService {
    * @since 0.5.0
    */
   readonly screencast: PlaywrightScreencastService;
+  /**
+   * Access session storage for the page's current origin.
+   *
+   * @see {@link Page.sessionStorage}
+   * @since 0.5.1
+   */
+  readonly sessionStorage: PlaywrightWebStorageService;
   /**
    * Navigates the page to the given URL.
    *
@@ -264,6 +282,7 @@ export interface PlaywrightPageService {
   readonly evaluate: <R, Arg = void>(
     pageFunction: PageFunction<Arg, R>,
     arg?: Arg,
+    options?: Parameters<Page["evaluate"]>[2],
   ) => Effect.Effect<R, PlaywrightError>;
   /**
    * Adds a script which would be evaluated in one of the following scenarios:
@@ -273,9 +292,10 @@ export interface PlaywrightPageService {
    * @see {@link Page.addInitScript}
    * @since 0.3.0
    */
-  readonly addInitScript: (
-    script: Parameters<Page["addInitScript"]>[0],
-    arg?: Parameters<Page["addInitScript"]>[1],
+  readonly addInitScript: <Arg>(
+    script: PageFunction<Arg, unknown> | { path?: string; content?: string },
+    arg?: Arg,
+    options?: Parameters<Page["addInitScript"]>[2],
   ) => Effect.Effect<void, PlaywrightError>;
   /**
    * Adds a `<script>` tag into the page with the desired url or content.
@@ -875,10 +895,12 @@ export class PlaywrightPage extends Context.Tag(
 
     return PlaywrightPage.of({
       clock: PlaywrightClock.make(page.clock),
+      localStorage: PlaywrightWebStorage.make(page.localStorage),
       keyboard: PlaywrightKeyboard.make(page.keyboard),
       mouse: PlaywrightMouse.make(page.mouse),
       touchscreen: PlaywrightTouchscreen.make(page.touchscreen),
       screencast: PlaywrightScreencast.make(page.screencast),
+      sessionStorage: PlaywrightWebStorage.make(page.sessionStorage),
       goto: (url, options) => use((p) => p.goto(url, options)),
       setContent: (html, options) => use((p) => p.setContent(html, options)),
       waitForTimeout: (timeout) => use((p) => p.waitForTimeout(timeout)),
@@ -895,9 +917,32 @@ export class PlaywrightPage extends Context.Tag(
         use((p) => p.waitForLoadState(state, options)),
       title: use((p) => p.title()),
       content: use((p) => p.content()),
-      evaluate: <R, Arg>(f: PageFunction<Arg, R>, arg?: Arg) =>
-        use((p) => p.evaluate<R, Arg>(f, arg as Arg)),
-      addInitScript: (script, arg) => use((p) => p.addInitScript(script, arg)),
+      evaluate: <R, Arg>(
+        f: PageFunction<Arg, R>,
+        arg?: Arg,
+        options?: Parameters<Page["evaluate"]>[2],
+      ) =>
+        use((p) =>
+          p.evaluate<R, Arg>(
+            f as unknown as Parameters<typeof p.evaluate<R, Arg>>[0],
+            arg as Arg,
+            options,
+          ),
+        ),
+      addInitScript: <Arg>(
+        script:
+          | PageFunction<Arg, unknown>
+          | { path?: string; content?: string },
+        arg?: Arg,
+        options?: Parameters<Page["addInitScript"]>[2],
+      ) =>
+        use((p) =>
+          p.addInitScript<Arg>(
+            script as unknown as Parameters<typeof p.addInitScript<Arg>>[0],
+            arg,
+            options,
+          ),
+        ).pipe(Effect.asVoid),
       addScriptTag: (options) => use((p) => p.addScriptTag(options)),
       addStyleTag: (options) => use((p) => p.addStyleTag(options)),
       exposeFunction: <A, E, R, Args extends unknown[]>(

--- a/src/playwright-types.ts
+++ b/src/playwright-types.ts
@@ -7,30 +7,38 @@ import type { ElementHandle, JSHandle } from "playwright-core";
 
 export type NoHandles<Arg> = Arg extends JSHandle
   ? never
-  : Arg extends object
-    ? { [Key in keyof Arg]: NoHandles<Arg[Key]> }
-    : Arg;
+  : Arg extends (...args: infer T) => PromiseLike<infer U>
+    ? (...args: T) => Promise<NoHandles<U>>
+    : Arg extends (...args: infer T) => infer R
+      ? (...args: T) => NoHandles<R>
+      : Arg extends object
+        ? { [Key in keyof Arg]: NoHandles<Arg[Key]> }
+        : Arg;
 
 export type Unboxed<Arg> =
   Arg extends ElementHandle<infer T>
     ? T
     : Arg extends JSHandle<infer T>
       ? T
-      : Arg extends NoHandles<Arg>
-        ? Arg
-        : Arg extends [infer A0]
-          ? [Unboxed<A0>]
-          : Arg extends [infer A0, infer A1]
-            ? [Unboxed<A0>, Unboxed<A1>]
-            : Arg extends [infer A0, infer A1, infer A2]
-              ? [Unboxed<A0>, Unboxed<A1>, Unboxed<A2>]
-              : Arg extends [infer A0, infer A1, infer A2, infer A3]
-                ? [Unboxed<A0>, Unboxed<A1>, Unboxed<A2>, Unboxed<A3>]
-                : Arg extends Array<infer T>
-                  ? Array<Unboxed<T>>
-                  : Arg extends object
-                    ? { [Key in keyof Arg]: Unboxed<Arg[Key]> }
-                    : Arg;
+      : Arg extends (...args: infer T) => PromiseLike<infer U>
+        ? (...args: T) => Promise<Unboxed<U>>
+        : Arg extends (...args: infer T) => infer R
+          ? (...args: T) => Unboxed<R>
+          : Arg extends NoHandles<Arg>
+            ? Arg
+            : Arg extends [infer A0]
+              ? [Unboxed<A0>]
+              : Arg extends [infer A0, infer A1]
+                ? [Unboxed<A0>, Unboxed<A1>]
+                : Arg extends [infer A0, infer A1, infer A2]
+                  ? [Unboxed<A0>, Unboxed<A1>, Unboxed<A2>]
+                  : Arg extends [infer A0, infer A1, infer A2, infer A3]
+                    ? [Unboxed<A0>, Unboxed<A1>, Unboxed<A2>, Unboxed<A3>]
+                    : Arg extends Array<infer T>
+                      ? Array<Unboxed<T>>
+                      : Arg extends object
+                        ? { [Key in keyof Arg]: Unboxed<Arg[Key]> }
+                        : Arg;
 
 export type PageFunction<Arg, R> =
   | string

--- a/src/web-storage.ts
+++ b/src/web-storage.ts
@@ -1,0 +1,115 @@
+import { Context, Effect, Option } from "effect";
+import type { WebStorage } from "playwright-core";
+import type { PlaywrightError } from "./errors";
+import { useHelper } from "./utils";
+
+/**
+ * @example
+ * ```ts
+ * import { Effect } from "effect";
+ * import { PlaywrightBrowser } from "effect-playwright";
+ *
+ * const program = Effect.gen(function* () {
+ *   const browser = yield* PlaywrightBrowser;
+ *   const page = yield* browser.newPage();
+ *   yield* page.goto("https://example.com");
+ *   yield* page.localStorage.setItem("theme", "dark");
+ *   return yield* page.localStorage.getItem("theme");
+ * });
+ * ```
+ *
+ * @category model
+ * @since 0.5.1
+ */
+export interface PlaywrightWebStorageService {
+  /**
+   * Removes all items from storage.
+   *
+   * @see {@link WebStorage.clear}
+   * @since 0.5.1
+   */
+  readonly clear: Effect.Effect<
+    Awaited<ReturnType<WebStorage["clear"]>>,
+    PlaywrightError
+  >;
+
+  /**
+   * Returns the value stored under the given name, if present.
+   *
+   * @see {@link WebStorage.getItem}
+   * @since 0.5.1
+   */
+  readonly getItem: (
+    name: Parameters<WebStorage["getItem"]>[0],
+  ) => Effect.Effect<
+    Option.Option<NonNullable<Awaited<ReturnType<WebStorage["getItem"]>>>>,
+    PlaywrightError
+  >;
+
+  /**
+   * Returns all items in storage as name/value pairs.
+   *
+   * @see {@link WebStorage.items}
+   * @since 0.5.1
+   */
+  readonly items: Effect.Effect<
+    Awaited<ReturnType<WebStorage["items"]>>,
+    PlaywrightError
+  >;
+
+  /**
+   * Removes the item stored under the given name.
+   *
+   * @see {@link WebStorage.removeItem}
+   * @since 0.5.1
+   */
+  readonly removeItem: (
+    name: Parameters<WebStorage["removeItem"]>[0],
+  ) => Effect.Effect<
+    Awaited<ReturnType<WebStorage["removeItem"]>>,
+    PlaywrightError
+  >;
+
+  /**
+   * Stores a value under the given name.
+   *
+   * @see {@link WebStorage.setItem}
+   * @since 0.5.1
+   */
+  readonly setItem: (
+    name: Parameters<WebStorage["setItem"]>[0],
+    value: Parameters<WebStorage["setItem"]>[1],
+  ) => Effect.Effect<
+    Awaited<ReturnType<WebStorage["setItem"]>>,
+    PlaywrightError
+  >;
+}
+
+/**
+ * @category tag
+ * @since 0.5.1
+ */
+export class PlaywrightWebStorage extends Context.Tag(
+  "effect-playwright/PlaywrightWebStorage",
+)<PlaywrightWebStorage, PlaywrightWebStorageService>() {
+  /**
+   * Creates a `PlaywrightWebStorage` from a Playwright `WebStorage` instance.
+   *
+   * @category constructor
+   * @since 0.5.1
+   */
+  static make(webStorage: WebStorage): PlaywrightWebStorageService {
+    const use = useHelper(webStorage);
+
+    return PlaywrightWebStorage.of({
+      clear: use((storage) => storage.clear()),
+      getItem: (name) =>
+        use((storage) => storage.getItem(name)).pipe(
+          Effect.map(Option.fromNullable),
+        ),
+      items: use((storage) => storage.items()),
+      removeItem: (name) => use((storage) => storage.removeItem(name)),
+      setItem: (name, value) => use((storage) => storage.setItem(name, value)),
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- upgrade playwright-core, playwright, and @playwright/test to 1.62.1
- add Credentials and WebStorage Effect wrappers
- expose Locator.waitForFunction and Playwright 1.62 evaluation options
- update evaluation argument typing for function-valued arguments

## Verification
- pnpm exec biome check --write .
- pnpm type-check
- pnpm test (101 tests passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency bump plus wider evaluate/addInitScript typings may affect consumers; new WebAuthn credential APIs touch auth testing paths but follow thin Playwright passthroughs with solid test coverage.
> 
> **Overview**
> Bumps **playwright-core**, **playwright**, and **@playwright/test** from 1.60.0 to **1.62.1** (lockfile included; Playwright now expects **Node ≥20**).
> 
> Adds Effect wrappers for Playwright 1.62 features: **`context.credentials`** (virtual WebAuthn install/create/get/delete) and **`page.localStorage` / `page.sessionStorage`**, both exported from the package entrypoint.
> 
> Extends the public API to match upstream: **`Locator.waitForFunction`**, and an optional third **`options`** argument on **`evaluate`**, **`evaluateHandle`**, **`addInitScript`**, and frame/context counterparts— notably **`{ exposeFunctions: true }`** so function-valued evaluate/init-script args work in the browser. **`NoHandles` / `Unboxed`** in `playwright-types.ts` are updated for those function arguments; existing tests are adjusted to cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dca854ae684de30363fa3d4d5805589e1622c84f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->