### PR TITLE
Simplify PlaywrightError tag to PlaywrightError

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -26,9 +26,7 @@ export type PlaywrightErrorReason = "Timeout" | "Unknown";
  * @category errors
  * @since 0.1.0
  */
-export class PlaywrightError extends Data.TaggedError(
-  "effect-playwright/errors/PlaywrightError",
-)<{
+export class PlaywrightError extends Data.TaggedError("PlaywrightError")<{
   reason: PlaywrightErrorReason;
   cause: unknown;
 }> {}

--- a/src/page.test.ts
+++ b/src/page.test.ts
@@ -934,10 +934,7 @@ layer(PlaywrightSpawner.layer(chromium))("Page", (it) => {
         .click()
         .pipe(Effect.flip);
 
-      assert.strictEqual(
-        result._tag,
-        "effect-playwright/errors/PlaywrightError",
-      );
+      assert.strictEqual(result._tag, "PlaywrightError");
     }).pipe(PlaywrightSpawner.withBrowser),
   );
 

--- a/src/playwright.test.ts
+++ b/src/playwright.test.ts
@@ -131,7 +131,7 @@ layer(Playwright.layer)("Playwright", (it) => {
       assert(capturedContext !== undefined, "Expected captured context");
       const error = yield* capturedContext.newPage.pipe(Effect.flip);
       assert(
-        error._tag === "effect-playwright/errors/PlaywrightError",
+        error._tag === "PlaywrightError",
         "Expected failure after scoped close",
       );
     }),
@@ -146,7 +146,7 @@ layer(Playwright.layer)("Playwright", (it) => {
         })
         .pipe(Effect.flip);
       assert(
-        result._tag === "effect-playwright/errors/PlaywrightError",
+        result._tag === "PlaywrightError",
         "Expected failure with invalid path",
       );
     }),
@@ -162,7 +162,7 @@ layer(Playwright.layer)("Playwright", (it) => {
         })
         .pipe(Effect.flip);
       assert(
-        result._tag === "effect-playwright/errors/PlaywrightError",
+        result._tag === "PlaywrightError",
         "Expected failure with timeout 0",
       );
       assert(result.reason === "Timeout", "Expected reason to be timeout");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit bdc6fe0bdc19e485a4c20bbb61c703b0aa67d12d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->