### PR TITLE
Publish prereleases under the next npm tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,4 +27,15 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: pnpm install
       - run: pnpm build
-      - run: pnpm publish --no-git-checks
+      - name: Select npm dist-tag
+        id: npm_tag
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          version_without_build="${version%%+*}"
+          if [[ "$version_without_build" == *-* ]]; then
+            echo "tag=next" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Publish package
+        run: pnpm publish --tag "${{ steps.npm_tag.outputs.tag }}" --no-git-checks


### PR DESCRIPTION
## Summary
- select the npm dist-tag from the package version
- publish prereleases under `next` and stable releases under `latest`
- ignore build metadata when detecting prerelease versions

## Verification
- `actionlint .github/workflows/*.yml`
- `pnpm publish --dry-run --tag next --no-git-checks`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release wiring; no runtime or package code changes, though a wrong tag choice could mislabel a release on npm.
> 
> **Overview**
> The **publish** workflow no longer runs a bare `pnpm publish`, which always used npm’s default **`latest`** tag.
> 
> It now reads `package.json` version, strips build metadata after `+`, and sets **`next`** when the version contains a prerelease segment (e.g. `0.8.0-1`) or **`latest`** for stable semver. Publish runs with `pnpm publish --tag <chosen> --no-git-checks`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf60e9a93e53d83a0247eb44a98b5f23b4773c63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->